### PR TITLE
Japanese Language Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,24 @@
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/drive-db@5.0.3/index.min.js"></script>
   <script src="static/main.js"></script>
+  <script>
+    (function(){
+      initDataTranslate()
+      drawMap()
+
+      // TODO This should load the data in parallel
+      map.once('style.load', function(e) {
+        loadPrefectureData(function(){
+          drawMapPrefectures(ddb.prefectures)
+          drawPrefectureTable(ddb.prefectures)
+        })
+      })
+
+      loadTrendData(function() {
+        drawTrendChart(ddb.trendData)
+      })
+    })()
+  </script>
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-2580539-41"></script>
   <script>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
   <a name="map"></a>
   <div class="center-offset">
-    <h4 data-ja="都道府県ごとの件数">Cases By Prefecture</h4>
+    <h4 data-ja="ウイルス感染マップ">Outbreak Map</h4>
   </div>
   <section id="map-legend">
     <div><span class="one">▉</span> <span data-ja="1-10 件">1-10 cases</span></div>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,11 @@
 <body>
 
   <header>
-    <h1>Coronavirus Disease (COVID-19) Japan Tracker</h1>
-    <em><small>Last Updated: <strong id="last-updated">-</strong></small></em>
+    <h1 data-ja="日本国内の新型コロナウイルス (COVID-19) 感染状況追跡">Coronavirus Disease (COVID-19) Japan Tracker</h1>
+    <em><small><span data-ja="最終更新:">Last Updated:</span> <strong id="last-updated">-</strong></small></em>
+    <br/><br/>
+    <button data-lang-picker="en">English</button>
+    <button data-lang-picker="ja">Japanese</button>
   </header>
 
   <section id="kpi">
@@ -55,31 +58,31 @@
         <td id="kpi-deceased"><div class="lds-dual-ring"></div></td>
       </tr>
       <tr class="kpi-labels">
-        <td>Confirmed</td>
-        <td>Recovered</td>
-        <td>Deceased</td>
+        <td data-ja="感染者数">Confirmed</td>
+        <td data-ja="回復者数">Recovered</td>
+        <td data-ja="死亡者数">Deceased</td>
       </tr>
     </table>
   </section>
 
   <a name="map"></a>
   <div class="center-offset">
-    <h4>Cases By Prefecture</h4>
+    <h4 data-ja="都道府県ごとの件数">Cases By Prefecture</h4>
   </div>
   <section id="map-legend">
-    <div><span class="one">▉</span> 1-10 cases</div>
-    <div><span class="two">▉</span> 11-25 cases</div>
-    <div><span class="three">▉</span> 26-50 cases</div>
-    <div><span class="four">▉</span> 51+ cases</div>
+    <div><span class="one">▉</span> <span data-ja="1-10 件">1-10 cases</span></div>
+    <div><span class="two">▉</span> <span data-ja="11-25 件">11-25 cases</span></div>
+    <div><span class="three">▉</span> <span data-ja="26-50 件">26-50 cases</span></div>
+    <div><span class="four">▉</span> <span data-ja="51+ 件">51+ cases</span></div>
   </section>
   <div id="map-container"></div>
 
   <section id="chart-legend-container">
-    <h4>Outbreak Spread Trend</h4>
+    <h4 data-ja="ウイルス感染の拡散傾向">Outbreak Spread Trend</h4>
     <div id="chart-legend">
-      <div><span class="one">▉</span> Confirmed</div>
-      <div><span class="two">▉</span> Recovered</div>
-      <div><span class="three">▉</span> Deceased</div>
+      <div><span class="one">▉</span> <span data-ja="感染者数">Confirmed</span></div>
+      <div><span class="two">▉</span> <span data-ja="回復者数">Recovered</span></div>
+      <div><span class="three">▉</span> <span data-ja="死亡者数">Deceased</span></div>
     </div>
   </section>
   <section id="trend-chart-container">
@@ -90,14 +93,14 @@
 
   <section>
     <a name="data"></a>
-    <h4>Prefecture Data</h4>
+    <h4 data-ja="都道府県ごとのデータ">Prefecture Data</h4>
     <table id="data-table">
       <thead>
         <tr>
-          <th>Prefecture</th>
-          <th>Confirmed</th>
-          <th>Recovered</th>
-          <th>Deceased</th>
+          <th data-ja="都道府県">Prefecture</th>
+          <th data-ja="感染者数">Confirmed</th>
+          <th data-ja="回復者数">Recovered</th>
+          <th data-ja="死亡者数">Deceased</th>
         </tr>
       </thead>
       <tbody>
@@ -108,7 +111,7 @@
 
   <section id="helpful-links">
     <a name="links"></a>
-    <h4>Helpful Links</h4>
+    <h4 data-ja="有益な情報源">Helpful Links</h4>
     <ul>
       <li>
         Information from the Tokyo Metropolitan Infectious Disease Surveillance Center<br/>
@@ -133,7 +136,7 @@
     </ul>
 
     <br/>
-    <h4>Primary Data Sources</h4>
+    <h4 data-ja="一次情報源">Primary Data Sources</h4>
     <ul>
       <li><a href="https://www.mhlw.go.jp/stf/houdou/houdou_list_202002.html">https://www.mhlw.go.jp/stf/houdou/houdou_list_202002.html</a></li>
       <li><a href="http://www.pref.fukuoka.lg.jp/contents/corona-kokunai.html">http://www.pref.fukuoka.lg.jp/contents/corona-kokunai.html</a></li>
@@ -148,10 +151,10 @@
   <!-- JS -->
   <script src="https://api.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.js"></script>
   <link href="https://api.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
-  <script src="https://unpkg.com/drive-db"></script>
+  <script src="https://cdn.jsdelivr.net/npm/drive-db@5.0.3/index.min.js"></script>
   <script src="static/main.js"></script>
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-2580539-41"></script>

--- a/static/main.js
+++ b/static/main.js
@@ -150,21 +150,21 @@ function drawTrendChart(sheetTrend) {
         labels: labelSet,
         datasets: [
           {
-            label: (LANG=='en'?'Deceased':'死亡者数'),
+            label: 'Deceased',
             borderColor: COLOR_DECEASED,
             backgroundColor: COLOR_DECEASED,
             fill: false,
             data: deceasedSet
           },
           {
-            label: (LANG=='en'?'Recovered':'回復者数'),
+            label: 'Recovered',
             borderColor: COLOR_RECOVERED,
             backgroundColor: COLOR_RECOVERED,
             fill: false,
             data: recoveredSet
           },
           {
-            label: (LANG=='en'?'Confirmed':'感染者数'),
+            label: 'Confirmed',
             borderColor: COLOR_CONFIRMED,
             backgroundColor: COLOR_CONFIRMED,
             fill: false,
@@ -189,17 +189,17 @@ function drawTrendChart(sheetTrend) {
           time: {
             parser: TIME_FORMAT,
             round: 'day',
-            tooltipFormat: 'll' // TODO ja switch
+            tooltipFormat: 'll'
           },
           scaleLabel: {
             display: true,
-            labelString: (LANG=='en'?'Date':'日付')
+            labelString: 'Date'
           }
         }],
         yAxes: [{
           scaleLabel: {
             display: true,
-            labelString: (LANG=='en'?'Cases':'件')
+            labelString: 'Cases'
           }
         }]
       }
@@ -372,6 +372,7 @@ function initDataTranslate() {
   // Language selector event handler
   document.querySelectorAll('[data-lang-picker]').forEach(pick => {
     pick.addEventListener('click', e => {
+      e.preventDefault()
       LANG = e.target.dataset.langPicker
       
       // Toggle the html lang tags
@@ -389,7 +390,6 @@ function initDataTranslate() {
   
       // Redraw the prefectures table and trend chart
       drawPrefectureTable(ddb.prefectures)
-      drawTrendChart(ddb.trendData)
       
       // Toggle the lang picker
       document.querySelectorAll('a[data-lang-picker]').forEach(function(el){
@@ -400,22 +400,3 @@ function initDataTranslate() {
     })
   })
 }
-
-
-function init() {
-  
-  initDataTranslate()
-  drawMap()
-
-  map.once('style.load', function(e) {
-    loadPrefectureData(function(){
-      drawMapPrefectures(ddb.prefectures)
-      drawPrefectureTable(ddb.prefectures)
-    })
-  })
-
-  loadTrendData(function() {
-    drawTrendChart(ddb.trendData)
-  })
-}
-init()

--- a/static/main.js
+++ b/static/main.js
@@ -261,7 +261,12 @@ function drawPrefectureTable(prefectures) {
   
   dataTable.innerHTML = dataTable.innerHTML + unspecifiedRow
   
-  dataTable.innerHTML = `${dataTable.innerHTML}<tr class="totals"><td>Total</td><td>${totalCases}</td><td>${totalRecovered}</td><td>${totalDeaths}</td></tr>`
+  let totalStr = 'Total'
+  if(LANG == 'ja'){
+    totalStr = '計'
+  }
+  
+  dataTable.innerHTML = `${dataTable.innerHTML}<tr class="totals"><td>${totalStr}</td><td>${totalCases}</td><td>${totalRecovered}</td><td>${totalDeaths}</td></tr>`
   
   drawKpis(totalCases, totalRecovered, totalDeaths)
   setPageTitleCount(totalCases)

--- a/static/main.js
+++ b/static/main.js
@@ -196,6 +196,29 @@ function setPageTitleCount(confirmed) {
 }
 
 
+function initDataTranslate() {
+  
+  // Make sure to include all the non-english languages in the page
+  const selector = '[data-ja]'
+  const parseNode = cb => document.querySelectorAll(selector).forEach(cb)
+
+  // Default website is in English. Extract it as the attr data-en="..."
+  parseNode(el => {
+    el.dataset['en'] = el.textContent
+  })
+
+  // For the language selector
+  document.querySelectorAll('[data-lang-picker]').forEach(pick => {
+    pick.addEventListener('click', e => {
+    	const lang = e.target.dataset.langPicker
+      parseNode(el => {
+        if (!el.dataset[lang]) return;
+        el.textContent = el.dataset[lang]
+      })
+    })
+  })
+}
+
 // Initialize Map
 var map = new mapboxgl.Map({
     container: 'map-container',
@@ -315,3 +338,5 @@ async function loadTrendData(){
   drawTrendChart(sheetTrend)
 }
 loadTrendData()
+
+initDataTranslate()


### PR DESCRIPTION
@khasunuma san has gone through the entire page and translated everything in to Japanese with his PR #8 

Seeing that there isn't much text, we feel it makes sense to handle translation switching entirely on the client-side. We can even set a url hash like `/#ja` to remember the language selection.

This PR is the first pass at catching all English and making sure it is translated.

Translation function by @franciscop 