### PR TITLE
Use correct UTF-8 meta tag for HTML5 documents

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,8 +4,7 @@
 
   <!-- Warning: Ugly code lies ahead -->
 
-
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
   <title>Japan COVID-19 Coronavirus Tracker</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i,800&display=swap" rel="stylesheet">


### PR DESCRIPTION
REF: https://github.com/h5bp/html5-boilerplate/blob/master/dist/index.html

@reustle 
