### PR TITLE
Copy CNAME into docs/ as part of the build

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-covid19japan.com

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+covid19japan.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 covid19japan.com
-=======
-covid19.liquidx.net
->>>>>>> 519d9b496625ffa7f293912e8a93ab6adef92851

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -34,6 +34,9 @@ module.exports = {
       chunks: ['index']
     }),
     new CopyPlugin([
+      { from: 'CNAME', to: '.', flatten: false }
+    ]),
+    new CopyPlugin([
       { from: 'static/**', to: '.', flatten: false }
     ]),
     new MiniCssExtractPlugin({


### PR DESCRIPTION
@reustle 

CNAME keeps on being cleaned out of docs/ on each build because of the clean step.

This PR copies it back into docs/ on each build to save ourselves from having to keep reverting the CNAME delete change.
