### PR TITLE
Fix chart axis labels

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,9 @@ function drawTrendChart(sheetTrend) {
       y: {
         show: true
       }
+    },
+    padding: {
+      right: 24
     }
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -214,6 +214,9 @@ function drawTrendChart(sheetTrend) {
             }
         },
         y: {
+          padding: {
+            bottom: 0
+          },
           tick: {
             values: [0, 100, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]
           }

--- a/src/index.js
+++ b/src/index.js
@@ -311,6 +311,9 @@ function drawDailyIncreaseChart(sheetTrend) {
     },
     legend: {
       hide: true
+    },
+    padding: {
+      right: 24
     }
   })
 }


### PR DESCRIPTION
Resolves #107 

- Removed padding on the y-axis so that 0 starts at the bottom
- Adding padding on the right to prevent the right-most label being cut off

After applying these changes:

### Mobile width
![Screen Shot 2020-03-25 at 0 09 03](https://user-images.githubusercontent.com/3714/77441562-ea7e8d00-6e2c-11ea-8856-5936a28d0c0e.png)

### Desktop width

![Screen Shot 2020-03-25 at 0 09 09](https://user-images.githubusercontent.com/3714/77441572-ec485080-6e2c-11ea-9ec0-1fe7fbba3551.png)

@reustle Hi! Here's a small change that resolves the axis and label issues in #107 
