### PR TITLE
Link to official Tokyo data tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ data that we use to cross check and verify.
 | Tochigi    | [新型コロナウイルス感染症について](http://www.pref.tochigi.lg.jp/e04/welfare/hoken-eisei/kansen/hp/coronakensahasseijyoukyou.html) |
 | Tochigi - Utsunomiya City | [宇都宮市における新型コロナウイルス感染症の発生状況](https://www.city.utsunomiya.tochigi.jp/kurashi/kenko/kansensho/etc/1023128.html)
 |Tokushima    | [新型コロナウイルス感染症について](https://www.pref.tokushima.lg.jp/ippannokata/kenko/kansensho/5034012#25)|
-|Tokyo    |[都内の最新感染動向](https://stopcovid19.metro.tokyo.lg.jp/)|
+|Tokyo    |[Latest updates on COVID-19 in Tokyo](https://stopcovid19.metro.tokyo.lg.jp/en)|
 |Tottori    ||
 |Toyama    ||
 |Wakayama    |[新型コロナウイルス感染症に関連する情報について](https://www.pref.wakayama.lg.jp/prefg/041200/d00203387.html)|

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ data that we use to cross check and verify.
 | Tochigi    | [新型コロナウイルス感染症について](http://www.pref.tochigi.lg.jp/e04/welfare/hoken-eisei/kansen/hp/coronakensahasseijyoukyou.html) |
 | Tochigi - Utsunomiya City | [宇都宮市における新型コロナウイルス感染症の発生状況](https://www.city.utsunomiya.tochigi.jp/kurashi/kenko/kansensho/etc/1023128.html)
 |Tokushima    | [新型コロナウイルス感染症について](https://www.pref.tokushima.lg.jp/ippannokata/kenko/kansensho/5034012#25)|
-|Tokyo    |[新型コロナウイルスに関連した患者の発生](https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/1007509.html)|
+|Tokyo    |[都内の最新感染動向](https://stopcovid19.metro.tokyo.lg.jp/)|
 |Tottori    ||
 |Toyama    ||
 |Wakayama    |[新型コロナウイルス感染症に関連する情報について](https://www.pref.wakayama.lg.jp/prefg/041200/d00203387.html)|

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ data that we use to cross check and verify.
 | Tochigi    | [新型コロナウイルス感染症について](http://www.pref.tochigi.lg.jp/e04/welfare/hoken-eisei/kansen/hp/coronakensahasseijyoukyou.html) |
 | Tochigi - Utsunomiya City | [宇都宮市における新型コロナウイルス感染症の発生状況](https://www.city.utsunomiya.tochigi.jp/kurashi/kenko/kansensho/etc/1023128.html)
 |Tokushima    | [新型コロナウイルス感染症について](https://www.pref.tokushima.lg.jp/ippannokata/kenko/kansensho/5034012#25)|
-|Tokyo    |[Latest updates on COVID-19 in Tokyo](https://stopcovid19.metro.tokyo.lg.jp/en)|
+|Tokyo    |[Latest updates on COVID-19 in Tokyo](https://stopcovid19.metro.tokyo.lg.jp/en) / Primary sources: [東京都新型コロナウイルス感染症対策本部報](https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html)|
 |Tottori    ||
 |Toyama    ||
 |Wakayama    |[新型コロナウイルス感染症に関連する情報について](https://www.pref.wakayama.lg.jp/prefg/041200/d00203387.html)|


### PR DESCRIPTION
The previous link was for a single day's report.

- old link: https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/1007509.html

The new link is an official OSS project launched in early March

- new link: https://stopcovid19.metro.tokyo.lg.jp
  - english: https://stopcovid19.metro.tokyo.lg.jp/en/
  - github: https://github.com/tokyo-metropolitan-gov/covid19


@reustle I updated the Tokyo source link. Stuck with the Japanese one, though an English link is also available. I believe a number of other prefectures have also forked and maintain similar sites, e.g.

- Chiba: https://covid19.civictech.chiba.jp/


