### PR TITLE
Reinstate throwing errors even if we're retrying.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,15 @@ if ('NodeList' in window && !NodeList.prototype.forEach) {
   };
 }
 
+// Returns true if this is a network error
+function isNetworkError(err) {
+  if (err && err.name && err.name == 'TypeError') {
+    if (err.toString() == 'TypeError: Failed to fetch') {
+      return true
+    }
+  }
+  return false
+}
 
 // Fetches data from the JSON_PATH but applies an exponential
 // backoff if there is an error.
@@ -76,6 +85,11 @@ function loadData(callback) {
     .catch(function(err) {
       retryFn(delay, err)
       delay *= 2  // exponential backoff.
+
+      // throwing the error again so it is logged in sentry/debuggable.
+      if (!isNetworkError(err)) {
+        throw err
+      }
     })
   }
 


### PR DESCRIPTION
This allows us to properly debug and log errors in sentry.

Allow us to do some simple filtering of network errors to avoid clogging up our logs.
