### PR TITLE
Add Prefecture trajectory visualization

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -132,6 +132,13 @@
     </div>
   </section>
 
+  <section id="prefecture-trajectory-container" class="embed-hide">
+    <h4 data-ja="都道府県別の患者数推移 (50例以上)">Confirmed Case trajectories by prefecture (> 100 cases / logarithmic)</h4>
+    <div id="prefecture-trajectory">
+        <div class="text-center"><div class="lds-dual-ring"></div></div>
+    </div>
+  </section>
+
   <section class="embed-hide">
     <h4 data-ja="都道府県ごとのデータ">Prefecture Data</h4>
     <table id="prefectures-table">

--- a/src/index.html
+++ b/src/index.html
@@ -133,7 +133,7 @@
   </section>
 
   <section id="prefecture-trajectory-container" class="embed-hide">
-    <h4 data-ja="都道府県別の患者数推移 (50例以上)">Confirmed Case trajectories by prefecture (> 100 cases / logarithmic)</h4>
+    <h4 data-ja="都道府県別の患者数推移 (50例以上)">Confirmed Case Trajectories by Prefecture (> 50 Cases)</h4>
     <div id="prefecture-trajectory">
         <div class="text-center"><div class="lds-dual-ring"></div></div>
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -519,6 +519,97 @@ function drawDailyIncreaseChart(sheetTrend) {
   })
 }
 
+function drawPrefectureTrajectoryChart(prefectures) {
+  const minimumConfirmed = 50;
+  const filteredPrefectures = _.filter(prefectures, function(prefecture) {
+    return prefecture.confirmed >= minimumConfirmed
+  });
+  const trajectories = _.map(filteredPrefectures, function(prefecture) {
+    const cumulativeConfirmed = _.reduce(prefecture.dailyConfirmedCount, function(result, value) {
+      if(result.length > 0) {
+        const sum = result[result.length - 1] + value;
+        result.push(sum);
+        return result;
+      } else {
+        return [value];
+      }
+    }, []);
+    const cumulativeConfirmedFromMinimum = _.filter(cumulativeConfirmed, function(value) {
+      return value >= minimumConfirmed;
+    });
+    return {
+      name: prefecture.name,
+      name_ja: prefecture.name_ja,
+      confirmed: prefecture.confirmed,
+      cumulativeConfirmed: cumulativeConfirmedFromMinimum
+    }
+  })
+
+  const columns = _.map(trajectories, function(prefecture) {
+    return [prefecture.name].concat(prefecture.cumulativeConfirmed);
+  });
+
+  const labelPosition = _.reduce(trajectories, function(result, value) {
+    // Show on second to last point to avoid cutoff
+    result[value.name] = value.cumulativeConfirmed.length - 1;
+    return result;
+  }, {});
+
+  const maxDays = _.reduce(_.values(labelPosition), function(a, b) {
+    return Math.max(a, b);
+  }, 0)
+
+  const nameMap = _.reduce(trajectories, function(result, value) {
+    if(LANG === 'en') {
+      result[value.name] = value.name;
+    } else {
+      result[value.name] = value.name_ja;
+    }
+    return result;
+  }, {});
+
+  c3.generate({
+    bindto: '#prefecture-trajectory',
+    axis: {
+      y: {
+        min: minimumConfirmed,
+        padding: {
+          bottom: 0
+        },
+      },
+      x: {
+        // Set max x value to be 1 greater to avoid label cutoff
+        max: maxDays + 1,
+        label: `Number of Days since ${minimumConfirmed}th case`,
+      }
+    },
+    data: {
+      columns: columns,
+      labels: {
+        format: function(v, id, i) {
+          if(id) {
+            if(i === labelPosition[id]) {
+              return id;
+            }
+          }
+        }
+      },
+      names: nameMap
+    },
+    grid: {
+      x: {
+        show: true
+      },
+      y: {
+        show: true
+      }
+    },
+    padding: {
+      right: 24
+    }
+  })
+}
+
 
 function drawPrefectureTable(prefectures, totals) {
 
@@ -807,6 +898,7 @@ function loadDataOnPage() {
       drawTravelRestrictions()
       drawTrendChart(ddb.trend)
       drawDailyIncreaseChart(ddb.trend)
+      drawPrefectureTrajectoryChart(ddb.prefectures);
     }
 
     whenMapAndDataReady()

--- a/src/index.scss
+++ b/src/index.scss
@@ -171,7 +171,9 @@ h1 {
   }
 }
 
-#trend-chart-container, #daily-increase-container {
+#trend-chart-container,
+#daily-increase-container,
+#prefecture-trajectory-container {
   //padding: 0px 10px;
 
   path.c3-line {


### PR DESCRIPTION
Implements https://github.com/reustle/covid19japan/issues/109

![Screen Shot 2020-03-28 at 11 22 03 PM](https://user-images.githubusercontent.com/3714/77825577-81a95480-714d-11ea-90b0-78b57b846759.png)

I've set an initial threshold of 50 cases for this chart. This threshold may need to be increased to 100 in coming days.

Hopefully this can give users some context on the relative rate of change of prefectures.

@reustle What do you think? I've tentatively added the chart just above the prefectures table.

In terms of the implementation, there's a fair bit of data manipulation going on. I think it's OK to keep doing this at runtime for now, but if necessary, perhaps the cumulative array can be moved into the data repository. 
