### PR TITLE
Style data points with provisional data in prefecture trajectory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -776,7 +776,7 @@ function drawPrefectureTrajectoryChart(prefectures) {
         if (d && d.index && d.index === lastIndex[d.id]) {
           let rgb = getRGBColor(color);
           let newColor = d3.color(color);
-          newColor.opacity = 0.4;
+          newColor.opacity = 0.6;
           return newColor;
         } else {
           return color;

--- a/src/index.js
+++ b/src/index.js
@@ -706,10 +706,10 @@ function drawPrefectureTrajectoryChart(prefectures) {
     return [prefecture.name].concat(prefecture.cumulativeConfirmed);
   });
 
-  const labelPosition = _.reduce(
+  // Mapping of id (name) to the last index for each trajectory.
+  const lastIndex = _.reduce(
     trajectories,
     function (result, value) {
-      // Show on second to last point to avoid cutoff
       result[value.name] = value.cumulativeConfirmed.length - 1;
       return result;
     },
@@ -717,7 +717,7 @@ function drawPrefectureTrajectoryChart(prefectures) {
   );
 
   const maxDays = _.reduce(
-    _.values(labelPosition),
+    _.values(lastIndex),
     function (a, b) {
       return Math.max(a, b);
     },
@@ -747,8 +747,8 @@ function drawPrefectureTrajectoryChart(prefectures) {
         },
       },
       x: {
-        // Set max x value to be 1 greater to avoid label cutoff
-        max: maxDays + 1,
+        // Set max x value to be 2 greater to avoid label cutoff
+        max: maxDays + 2,
         label: `Number of Days since ${minimumConfirmed}th case`,
       },
     },
@@ -757,13 +757,23 @@ function drawPrefectureTrajectoryChart(prefectures) {
       labels: {
         format: function (v, id, i) {
           if (id) {
-            if (i === labelPosition[id]) {
+            if (i === lastIndex[id]) {
               return id;
             }
           }
         },
       },
       names: nameMap,
+      color: function (color, d) {
+        if (d && d.index && d.index === lastIndex[d.id]) {
+          let rgb = getRGBColor(color);
+          let newColor = d3.color(color);
+          newColor.opacity = 0.4;
+          return newColor;
+        } else {
+          return color;
+        }
+      },
     },
     grid: {
       x: {

--- a/src/index.js
+++ b/src/index.js
@@ -355,13 +355,6 @@ function drawMap() {
   );
 }
 
-function getRGBColor(color) {
-  return color
-    .substring(4, color.length - 1)
-    .replace(/ /g, "")
-    .split(",");
-}
-
 function drawTrendChart(sheetTrend) {
   var cols = {
     Date: ["Date"],
@@ -398,8 +391,9 @@ function drawTrendChart(sheetTrend) {
       x: "Date",
       color: function (color, d) {
         if (d && d.index === cols.Date.length - 2) {
-          let rgb = getRGBColor(color);
-          return `rgba(${rgb[0]},${rgb[1]},${rgb[2]},${0.6})`;
+          let newColor = d3.color(color);
+          newColor.opacity = 0.6;
+          return newColor;
         } else {
           return color;
         }
@@ -774,7 +768,6 @@ function drawPrefectureTrajectoryChart(prefectures) {
       names: nameMap,
       color: function (color, d) {
         if (d && d.index && d.index === lastIndex[d.id]) {
-          let rgb = getRGBColor(color);
           let newColor = d3.color(color);
           newColor.opacity = 0.6;
           return newColor;
@@ -925,7 +918,7 @@ function drawPrefectureTable(prefectures, totals) {
         <td class="trend"></td>
         <td class="count">${totals.confirmed}</td>
         <td class="count">${totals.recovered}</td>
-        <td class="count">${totals.deceased}</td> 
+        <td class="count">${totals.deceased}</td>
         </tr>`;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -716,6 +716,14 @@ function drawPrefectureTrajectoryChart(prefectures) {
     {}
   );
 
+  const regions = _.mapValues(lastIndex, function (value) {
+    if (value > 0) {
+      return [{ start: value - 1, end: value, style: "dashed" }];
+    } else {
+      return [];
+    }
+  });
+
   const maxDays = _.reduce(
     _.values(lastIndex),
     function (a, b) {
@@ -774,6 +782,7 @@ function drawPrefectureTrajectoryChart(prefectures) {
           return color;
         }
       },
+      regions: regions,
     },
     grid: {
       x: {


### PR DESCRIPTION
Reusing the approache from https://github.com/reustle/covid19japan/pull/123, I've used regions and color changes to make the latest data point look different to indicate it is provisional. I haven't modified the tooltip yet though.

Also uses [d3.color API](https://github.com/d3/d3-color/blob/v1.4.0/README.md)  for color manipulaton rather than our own custom code. We're already including all of d3 anyway!

Looks like this:

![Screen Shot 2020-03-31 at 1 29 41](https://user-images.githubusercontent.com/3714/77937306-1d25fb00-72ef-11ea-90aa-dcf1d4433105.png)


 @reustle As requested

_This PR doesn't include a production build_