### PR TITLE
[#158] Center embed map footnote

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -116,7 +116,7 @@
     <div><span class="four">▉</span> <span data-ja="201+ 件">201+ cases</span></div>
   </section>
   <div id="map-container"></div>
-  <span class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></span>
+  <p class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></p>
 
   <section id="trend-chart-container" class="embed-hide">
     <h4 data-ja="ウイルス感染の拡散傾向">Outbreak Spread Trend</h4>

--- a/src/index.scss
+++ b/src/index.scss
@@ -10,10 +10,6 @@ body {
   line-height: 25px;
   color: $primary-black;
   font-size: 16px;
-
-  .embed-show {
-    display: none;
-  }
 }
 h1 {
   font-size: 48px;
@@ -29,6 +25,7 @@ h5 {
   margin-bottom: 5px;
 }
 .footnote {
+  display: block;
   font-weight: 400;
   font-size: 15px;
   padding-left: 5px;
@@ -271,8 +268,15 @@ footer {
   }
 }
 
-body.embed {
-  .embed-hide { display: none; }
-  .embed-show { display: block; }
-  span.embed-show { display: inline; }
+body {
+  &.embed {
+    .embed-hide {
+      display: none;
+    }
+  }
+  &:not(.embed) {
+    .embed-show {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
Fixes text alignment issue from https://github.com/reustle/covid19japan/issues/158
cc @reustle 

## Proposed Changes
- Convert embed `footnote` to `p` tag so that centered margins will apply to block level element
- Small refactor of `embed-hide` / `embed-show` CSS to reduce specificity collisions
  - ex. Setting `display: block` on the existing footnote `span` would be overwritten by the `body.embed span.embed-show { display: inline; }`
  - This could use a quick IE11 test if you have the capacity, [Can I Use](https://caniuse.com/#search=%3Anot) says that it should work though