### PR TITLE
Only send 5% of errors to Sentry

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,7 @@
       Sentry.init({
         dsn: 'https://1c7127f5f5b2432d99a5bf44a3b74d08@sentry.io/2967034',
         debug: false,
+        sampleRate: 0.05,
         integrations: [
           new Sentry.Integrations.CaptureConsole({
             levels: ['error']


### PR DESCRIPTION
See: https://docs.sentry.io/error-reporting/configuration/?platform=javascript#sample-rate

> Configures the sample rate as a percentage of events to be sent in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of events are sent. If set to 0.1 only 10% of events will be sent. Events are picked randomly.

@reustle If total errors sent to Sentry is a problem, sampling errors is one way to mitigate. Let's try 5%?
