### PR TITLE
Remove unused dependency chart.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2120,32 +2120,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "chart.js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
-      "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
-      "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
-    },
-    "chartjs-color": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "requires": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@babel/core": "^7.7.7",
     "apexcharts": "^3.17.1",
     "c3": "^0.7.15",
-    "chart.js": "^2.9.3",
     "classlist-polyfill": "^1.2.0",
     "core-js": "^3.6.4",
     "d3": "^5.15.0",


### PR DESCRIPTION
We have three charting libraries now: c3.js, chart.js, apexcharts. Might as well eliminate the one we're not using?

@reustle Just some quick cleanup
