### PR TITLE
Use date-fns instead of moment.js for smaller file size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2996,10 +2996,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.1.tgz",
+      "integrity": "sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w=="
     },
     "debug": {
       "version": "4.1.1",
@@ -6452,6 +6451,12 @@
           "requires": {
             "restore-cursor": "^2.0.0"
           }
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
         },
         "figures": {
           "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7000,11 +7000,6 @@
         "minimist": "0.0.8"
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "i18next-browser-languagedetector": "^4.0.2",
     "loc-i18next": "^0.1.4",
     "lodash": "^4.17.15",
-    "moment": "^2.24.0",
     "tippy.js": "^6.1.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "classlist-polyfill": "^1.2.0",
     "core-js": "^3.6.4",
     "d3": "^5.15.0",
+    "date-fns": "^2.11.1",
     "express": "^4.17.1",
     "i18next": "^19.3.4",
     "i18next-browser-languagedetector": "^4.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import _ from "lodash";
 import tippy from "tippy.js";
 import * as d3 from "d3";
 import * as c3 from "c3";
-import moment from "moment";
+import { formatDistance, parse } from "date-fns";
+import { enUS, ja } from "date-fns/locale";
 
 // Localization deps
 import i18next from "i18next";
@@ -24,7 +25,6 @@ mapboxgl.accessToken =
   "pk.eyJ1IjoicmV1c3RsZSIsImEiOiJjazZtaHE4ZnkwMG9iM3BxYnFmaDgxbzQ0In0.nOiHGcSCRNa9MD9WxLIm7g";
 const PREFECTURE_JSON_PATH = "static/prefectures.geojson";
 const JSON_PATH = "https://data.covid19japan.com/summary/latest.json";
-const TIME_FORMAT = "YYYY-MM-DD";
 const COLOR_ACTIVE = "rgb(223,14,31)";
 const COLOR_CONFIRMED = "rgb(244,67,54)";
 const COLOR_RECOVERED = "rgb(25,118,210)";
@@ -840,18 +840,22 @@ function drawLastUpdated(lastUpdated) {
 
   // TODO we should be parsing the date, but I
   // don't trust the user input on the sheet
-  const lastUpdatedMoment = moment(
-    lastUpdated.slice(0, -4),
-    "MMM DD YYYY, HH:mm"
-  ).utcOffset(9, true); // JST offset
-  if (!lastUpdatedMoment.isValid()) {
+  let lastUpdatedMoment;
+  try {
+    lastUpdatedMoment = parse(
+      lastUpdated.slice(0, -4),
+      "MMMM d yyyy, HH:mm",
+      new Date()
+    );
+  } catch (e) {
     // Fall back to raw value on failed parse
     display.textContent = lastUpdated;
     return;
   }
+  const now = new Date();
   const relativeTime = {
-    en: lastUpdatedMoment.clone().locale("en").fromNow(),
-    ja: lastUpdatedMoment.clone().locale("ja").fromNow(),
+    en: formatDistance(lastUpdatedMoment, now, { local: enUS }),
+    ja: formatDistance(lastUpdatedMoment, now, { locale: ja }),
   };
 
   display.textContent = relativeTime[LANG];

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import _ from "lodash";
 import tippy from "tippy.js";
 import * as d3 from "d3";
 import * as c3 from "c3";
-import { formatDistance, parse } from "date-fns";
+import { formatDistanceToNow, parse } from "date-fns";
 import { enUS, ja } from "date-fns/locale";
 
 // Localization deps
@@ -852,10 +852,12 @@ function drawLastUpdated(lastUpdated) {
     display.textContent = lastUpdated;
     return;
   }
-  const now = new Date();
   const relativeTime = {
-    en: formatDistance(lastUpdatedMoment, now, { local: enUS }),
-    ja: formatDistance(lastUpdatedMoment, now, { locale: ja }),
+    en: formatDistanceToNow(lastUpdatedMoment, {
+      local: enUS,
+      addSuffix: true,
+    }),
+    ja: formatDistanceToNow(lastUpdatedMoment, { locale: ja, addSuffix: true }),
   };
 
   display.textContent = relativeTime[LANG];


### PR DESCRIPTION
Moment.js is a nice library for date manipulation, but it's known to be [not so great for performance and build size](https://github.com/you-dont-need/You-Dont-Need-Momentjs). Since we don't heavily do date manipulation here, and have experience some performance issues, I thought that switching out moment.js would be a quick win.

- `date-fns` is a functional and composable library of date functions: https://date-fns.org/

## Build size

Before:
```
Hash: 216000d57e79c20d0dc0
Version: webpack 4.42.0
Time: 9457ms
Built at: 04/04/2020 6:04:03 PM
                     Asset       Size  Chunks                          Chunk Names
                     CNAME   17 bytes          [emitted]               
                embed.html   9.91 KiB          [emitted]               
                 index.css   7.19 KiB       0  [emitted]               index
             index.css.map   9.61 KiB       0  [emitted] [dev]         index
                index.html    9.9 KiB          [emitted]               
                  index.js    974 KiB       0  [emitted]        [big]  index
      index.js.LICENSE.txt  170 bytes          [emitted]               
              index.js.map   3.54 MiB       0  [emitted] [dev]         index
        static/favicon.ico     15 KiB          [emitted]               
        static/favicon.png   11.7 KiB          [emitted]               
            static/map.jpg   61.9 KiB          [emitted]               
static/prefectures.geojson    687 KiB          [emitted]        [big]  
```

After:

```
Hash: a04fb2b67838ee571d98
Version: webpack 4.42.0
Time: 17480ms
Built at: 04/04/2020 5:59:57 PM
                     Asset       Size  Chunks                          Chunk Names
                     CNAME   17 bytes          [emitted]               
                embed.html   9.91 KiB          [emitted]               
                 index.css   7.19 KiB       0  [emitted]               index
             index.css.map   9.61 KiB       0  [emitted] [dev]         index
                index.html    9.9 KiB          [emitted]               
                  index.js    757 KiB       0  [emitted]        [big]  index
      index.js.LICENSE.txt  170 bytes          [emitted]               
              index.js.map   2.93 MiB       0  [emitted] [dev]         index
        static/favicon.ico     15 KiB          [emitted]               
        static/favicon.png   11.7 KiB          [emitted]               
            static/map.jpg   61.9 KiB          [emitted]               
static/prefectures.geojson    687 KiB          [emitted]        [big]
```

That's a roughly 200kb (20%!) saving on the emitted javascript, before minification etc. I believe that a lot of the cruft in moment comes from having all the locales loaded, as well as not supporting tree-shaking.

## UI Changes

This comes with a minor change: the "human" formatting of the date is slightly different in some situations (not all):

e.g. 
- Before (moment): 
  - en: `an hour ago`
  - ja: `1時間前`
- After (date-fns): `about 1 hour ago`
  - en: `about 1 hour ago`
  - ja: `約1時間前`

I don't think its a meaningful difference, but I think its important to note.

---

@reustle What do you think?
