### PR TITLE
Destroy charts when redrawing.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1126,8 +1126,6 @@ function loadDataOnPage() {
     ddb.trend = jsonData.daily;
     ddb.lastUpdated = jsonData.updated;
 
-    console.log("load data");
-
     drawKpis(ddb.totals, ddb.totalsDiff);
     if (!document.body.classList.contains("embed-mode")) {
       drawLastUpdated(ddb.lastUpdated);


### PR DESCRIPTION
Chart redrawing code can be called multiple times (especially after 5 mins the data is refreshed.)

We didn't destroy the old chart instances so it ran out of memory! (This fixes also lots of out of memory errors we're seeing in sentry too.)
