### PR TITLE
Use 感染者 instead of 患者

### DIFF
--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -20,7 +20,7 @@
   "deaths": "死亡者数",
   "helpful-links": "有益な情報源",
   "primary-data-sources": "一次情報源",
-  "confirmed-case-trajectories-by-prefecture": "都道府県別の患者数推移 (100例以上)",
+  "confirmed-case-trajectories-by-prefecture": "都道府県別の感染者数推移 (100例以上)",
   "traveling-into-japan": "入国制限について",
   "about-travel-restriction": "下記に各国の入国制限に関する一覧がございます。詳細をご覧いただくには、国名をクリックしてください。",
   "banned-from-entering-japan": "入国拒否",


### PR DESCRIPTION
Fixes an inconsistency in the translations that was initially covered in #133 by @Kay-Cube but was accidentally reverted somewhere along the line.


FYI @reustle 
