### PR TITLE
Remove Data Sources List

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -222,13 +222,6 @@
         </a>
       </li>
     </ul>
-    <br/>
-    <h4 data-i18n="primary-data-sources">Primary Data Sources</h4>
-    <ul>
-      <li><a href="https://www.mhlw.go.jp/stf/houdou/houdou_list_202002.html">https://www.mhlw.go.jp/stf/houdou/houdou_list_202002.html</a></li>
-      <li><a href="https://www3.nhk.or.jp/news/special/coronavirus/latest-news/">https://www3.nhk.or.jp/news/special/coronavirus/latest-news/</a></li>
-      <li><a href="https://github.com/reustle/covid19japan#data-sources">See all sources</a></li>
-    </ul>
   </section>
 
   <footer>

--- a/src/index.html
+++ b/src/index.html
@@ -251,7 +251,7 @@
     <p>
       Supported by <a href="https://reustle.co" target="_blank">Reustle K.K.</a>, <a href="https://mapbox.com/community/" target="_blank">Mapbox</a>, and <a href="https://sentry.io" target="_blank">Sentry.io</a><br/>
       Contribute to <a href="https://github.com/reustle/covid19japan">covid19japan on GitHub</a><br/>
-      Learn about our <a href="https://github.com/reustle/covid19japan-data/">full patient database</a>
+      Data sourced from Prefectural Governments and MHLW (<a href="https://github.com/reustle/covid19japan-data/">Full Details</a>)
     </p>
   </footer>
 


### PR DESCRIPTION
Since we've put a lot of work into listing our information sources on the data repo, we've discussed removing this list to drive users to that repo for more info.

Agreed @liquidx @l15n ?