### PR TITLE
Changed header toolbar to new layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,0 @@
-Oops! You are currently viewing the old version of <a href="https://covid19japan.com">covid19japan.com</a>.
-<br/><br/>
-Please refresh this page to try again.

--- a/src/components/Header/ToggleLangPicker.js
+++ b/src/components/Header/ToggleLangPicker.js
@@ -2,14 +2,14 @@ const toggleLangPicker = (lang) => {
   // Toggle the lang picker
   if (document.querySelectorAll("a[data-lang-picker]")) {
     document.querySelectorAll("a[data-lang-picker]").forEach((el) => {
-      el.style.display = "inline";
+      el.className = "";
     });
 
     const currentLangPicker = document.querySelector(
       `a[data-lang-picker=${lang}]`
     );
     if (currentLangPicker) {
-      currentLangPicker.style.display = "none";
+      currentLangPicker.className = "active";
     }
   }
 };

--- a/src/index.html
+++ b/src/index.html
@@ -70,13 +70,12 @@
   </script>
 
   <header class="embed-hide">
-    <div class="lang-picker">
-      <a href="#" data-lang-picker='ja'>🇯🇵 日本語</a>
-      <a href="#" data-lang-picker='en' style="display:none">🇺🇸 English</a>
-    </div>
-    
     <h1 data-i18n="covid-19-tracker">Japan COVID-19 Coronavirus Tracker</h1>
-    <div>
+    <div class="toolbar">
+      <div class="lang-picker">
+        <a href="#" data-lang-picker='en'>EN 🇺🇸</a> |
+        <a href="#" data-lang-picker='ja'>JP 🇯🇵</a>
+      </div>
       <em>
         <span data-i18n="last-updated">Last Updated:</span> <strong id="last-updated">-</strong>
       </em>

--- a/src/index.scss
+++ b/src/index.scss
@@ -57,7 +57,8 @@ header {
       a {
         text-decoration: none;
         &.active {
-          text-decoration: underline;
+          padding-bottom: 4px;
+          border-bottom: solid 2px black;
           font-weight: 700;
         }
       }

--- a/src/index.scss
+++ b/src/index.scss
@@ -47,11 +47,20 @@ section, header, footer {
 header {
   padding-top: 10px;
 
-  .lang-picker {
-    text-align: right;
-
-    a {
-      text-decoration: none;
+  .toolbar {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    
+    .lang-picker {
+      display: inline;
+      a {
+        text-decoration: none;
+        &.active {
+          text-decoration: underline;
+          font-weight: 700;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
@reustle
<img width="695" alt="Screen Shot 2020-04-11 at 12 14 06 PM" src="https://user-images.githubusercontent.com/7063634/79037376-f40a4200-7bed-11ea-9081-3e7894f73a4e.png">
 Trying to chnage the underline styles will push in next commit

Fixes https://github.com/reustle/covid19japan/issues/215