### PR TITLE
Interactive map with a popup to show prefecture status

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,0 @@
-Oops! You are currently viewing the old version of <a href="https://covid19japan.com">covid19japan.com</a>.
-<br/><br/>
-Please refresh this page to try again.

--- a/src/components/OutbreakMap/DrawMap.js
+++ b/src/components/OutbreakMap/DrawMap.js
@@ -12,6 +12,7 @@ const drawMap = (mapboxgl, map) => {
       showZoom: true,
     })
   );
+
   return map;
 };
 

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import {
   PREFECTURE_JSON_PATH,
   PREFECTURE_PAINT,
@@ -117,7 +118,19 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       const active =
         thisPrefecture[0].confirmed -
         ((thisPrefecture[0].recovered || 0) + (thisPrefecture[0].deaths || 0));
-      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Recovered: ${recovered}<br />Deaths: ${deaths}<br />Active: ${active}`;
+      const html = `<h3 data-i18n="prefectures.${name}">${i18next.t(
+        "prefectures." + name
+      )}</h3>
+          <span data-i18n="confirmed">${i18next.t(
+            "confirmed"
+          )}</span>: ${confirmed}<br />
+          <span data-i18n="recovered">${i18next.t(
+            "recovered"
+          )}</span>: ${recovered}<br />
+          <span data-i18n="deaths">${i18next.t(
+            "deaths"
+          )}</span>: ${deaths}<br />
+          <span data-i18n="active">${i18next.t("active")}</span>: ${active}`;
       popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
     } else {
       popup.remove();

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -96,6 +96,31 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
     map.setPaintProperty("prefecture-layer", "fill-color", prefecturePaint);
   }
 
+  // Map popup for prefectures
+  const popup = new mapboxgl.Popup({
+    closeButton: false,
+    closeOnClick: false,
+  });
+
+  map.on("mousemove", function (e) {
+    const feature = map.queryRenderedFeatures(e.point, {
+      layers: ["prefecture-layer"],
+    })[0];
+    if (feature) {
+      const thisPrefecture = ddb.prefectures.filter((p) => {
+        return p.name === feature.properties.NAME_1;
+      });
+      const name = thisPrefecture[0].name;
+      const confirmed = thisPrefecture[0].confirmed;
+      const deaths = thisPrefecture[0].deaths;
+      const recovered = thisPrefecture[0].recovered;
+      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Deaths: ${deaths}<br />Recovered: ${recovered}`;
+      popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
+    } else {
+      popup.remove();
+    }
+  });
+
   return { map, ddb };
 };
 

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -117,7 +117,7 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       const active =
         thisPrefecture[0].confirmed -
         ((thisPrefecture[0].recovered || 0) + (thisPrefecture[0].deaths || 0));
-      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Deaths: ${deaths}<br />Recovered: ${recovered}<br />Active: ${active}`;
+      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Recovered: ${recovered}<br />Deaths: ${deaths}<br />Active: ${active}`;
       popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
     } else {
       popup.remove();

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -114,7 +114,10 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       const confirmed = thisPrefecture[0].confirmed;
       const deaths = thisPrefecture[0].deaths;
       const recovered = thisPrefecture[0].recovered;
-      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Deaths: ${deaths}<br />Recovered: ${recovered}`;
+      const active =
+        thisPrefecture[0].confirmed -
+        ((thisPrefecture[0].recovered || 0) + (thisPrefecture[0].deaths || 0));
+      const html = `<h3>${name}</h3>Confirmed: ${confirmed}<br />Deaths: ${deaths}<br />Recovered: ${recovered}<br />Active: ${active}`;
       popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
     } else {
       popup.remove();

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -111,6 +111,16 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       const thisPrefecture = ddb.prefectures.filter((p) => {
         return p.name === feature.properties.NAME_1;
       });
+      const increment =
+        thisPrefecture[0].dailyConfirmedCount[
+          thisPrefecture[0].dailyConfirmedCount.length - 1
+        ];
+
+      if (increment > 0) {
+        var popupIncrementSpan = `<span class='popup-increment'>(+${increment})</span>`;
+      } else {
+        var popupIncrementSpan = "";
+      }
       const name = thisPrefecture[0].name;
       const confirmed = thisPrefecture[0].confirmed;
       const deaths = thisPrefecture[0].deaths;
@@ -118,19 +128,21 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       const active =
         thisPrefecture[0].confirmed -
         ((thisPrefecture[0].recovered || 0) + (thisPrefecture[0].deaths || 0));
-      const html = `<h3 data-i18n="prefectures.${name}">${i18next.t(
+      const html = `<div class="map-popup">
+      <h3 data-i18n="prefectures.${name}">${i18next.t(
         "prefectures." + name
       )}</h3>
           <span data-i18n="confirmed">${i18next.t(
             "confirmed"
-          )}</span>: ${confirmed}<br />
+          )}</span>: ${confirmed} ${popupIncrementSpan}<br />
           <span data-i18n="recovered">${i18next.t(
             "recovered"
           )}</span>: ${recovered}<br />
           <span data-i18n="deaths">${i18next.t(
             "deaths"
           )}</span>: ${deaths}<br />
-          <span data-i18n="active">${i18next.t("active")}</span>: ${active}`;
+          <span data-i18n="active">${i18next.t("active")}</span>: ${active}
+          </div>`;
       popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
     } else {
       popup.remove();

--- a/src/index.scss
+++ b/src/index.scss
@@ -316,3 +316,13 @@ img.emoji {
 .country-link {
   white-space: nowrap;
 }
+
+.map-popup {
+  font-size: 12px;
+
+  span.popup-increment {
+    color: rgb(244,67,54);
+    font-size: 10px;
+  }
+
+}


### PR DESCRIPTION
Hi @reustle ,
This PR adds an interactive map with a popup on prefectures. The popup supports i18n as well as indicates the increment. This feature is from https://covid19kerala.info/, originally by @geohacker.

Also covers https://github.com/reustle/covid19japan/issues/32.

![image](https://user-images.githubusercontent.com/1372136/79239681-d10cb600-7eab-11ea-8e86-0b3d3b126420.png)
 
