### PR TITLE
Performance improvements: Use DCL, separate macrotasks

### DIFF
--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -63,6 +63,11 @@ const drawPrefectureTrend = (
   return prefectureTrendCharts;
 };
 
+// Run CPU intensive processing in a separate macrotask
+const enqueueMacrotask = (callback, delay = 0) => {
+  setTimeout(callback, delay);
+};
+
 const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
   // Draw the Cases By Prefecture table
   const dataTable = document.querySelector("#prefectures-table");
@@ -131,14 +136,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
         </tr>`;
-      setTimeout(() => {
+      enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
           `#Unspecified-trend`,
           pref.dailyConfirmedCount,
           maxConfirmedIncrease,
           prefectureTrendCharts
         );
-      }, 0);
+      });
     } else if (pref.name == "Port Quarantine" || pref.name == "Port of Entry") {
       // Override Port Quartantine name as "Port of Entry". The name in the spreadsheet is
       //  confusing.
@@ -154,14 +159,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
         </tr>`;
-      setTimeout(() => {
+      enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
           `#PortOfEntry-trend`,
           pref.dailyConfirmedCount,
           maxConfirmedIncrease,
           prefectureTrendCharts
         );
-      }, 0);
+      });
     } else if (pref.name == "Total") {
       // Skip
     } else {
@@ -177,14 +182,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
       `;
-      setTimeout(() => {
+      enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
           `#${pref.name}-trend`,
           pref.dailyConfirmedCount,
           maxConfirmedIncrease,
           prefectureTrendCharts
         );
-      }, 0);
+      });
     }
     return true;
   });

--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -131,12 +131,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
         </tr>`;
-      prefectureTrendCharts = drawPrefectureTrend(
-        `#Unspecified-trend`,
-        pref.dailyConfirmedCount,
-        maxConfirmedIncrease,
-        prefectureTrendCharts
-      );
+      setTimeout(() => {
+        prefectureTrendCharts = drawPrefectureTrend(
+          `#Unspecified-trend`,
+          pref.dailyConfirmedCount,
+          maxConfirmedIncrease,
+          prefectureTrendCharts
+        );
+      }, 0);
     } else if (pref.name == "Port Quarantine" || pref.name == "Port of Entry") {
       // Override Port Quartantine name as "Port of Entry". The name in the spreadsheet is
       //  confusing.
@@ -152,12 +154,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
         </tr>`;
-      prefectureTrendCharts = drawPrefectureTrend(
-        `#PortOfEntry-trend`,
-        pref.dailyConfirmedCount,
-        maxConfirmedIncrease,
-        prefectureTrendCharts
-      );
+      setTimeout(() => {
+        prefectureTrendCharts = drawPrefectureTrend(
+          `#PortOfEntry-trend`,
+          pref.dailyConfirmedCount,
+          maxConfirmedIncrease,
+          prefectureTrendCharts
+        );
+      }, 0);
     } else if (pref.name == "Total") {
       // Skip
     } else {
@@ -173,12 +177,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="count">${pref.deceased ? pref.deceased : ""}</td>
         <td class="count">${pref.active || ""}</td>
       `;
-      prefectureTrendCharts = drawPrefectureTrend(
-        `#${pref.name}-trend`,
-        pref.dailyConfirmedCount,
-        maxConfirmedIncrease,
-        prefectureTrendCharts
-      );
+      setTimeout(() => {
+        prefectureTrendCharts = drawPrefectureTrend(
+          `#${pref.name}-trend`,
+          pref.dailyConfirmedCount,
+          maxConfirmedIncrease,
+          prefectureTrendCharts
+        );
+      }, 0);
     }
     return true;
   });

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,16 @@ const ddb = {
   travelRestrictions,
 };
 
+ddb.isLoaded = function () {
+  return !!ddb.lastUpdated;
+};
+ddb.isUpdated = function () {
+  return (
+    ddb.isLoaded() &&
+    (!ddb.previouslyUpdated || ddb.lastUpdated > ddb.previouslyUpdated)
+  );
+};
+
 let map = undefined;
 let tippyInstances;
 
@@ -136,11 +146,13 @@ const setLang = (lng) => {
       if (document.getElementById("travel-restrictions")) {
         drawTravelRestrictions(ddb);
       }
-      prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
-        ddb.prefectures,
-        prefectureTrajectoryChart,
-        LANG
-      );
+      if (!ddb.isLoaded()) {
+        prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
+          ddb.prefectures,
+          prefectureTrajectoryChart,
+          LANG
+        );
+      }
     }
 
     tippyInstances = updateTooltipLang(tippyInstances);

--- a/src/index.js
+++ b/src/index.js
@@ -221,8 +221,7 @@ const startReloadTimer = () => {
   setTimeout(() => location.reload(), reloadInterval * 60 * 60 * 1000);
 };
 
-window.addEventListener("DOMContentLoaded", () => {
-  initDataTranslate(setLang);
+const initMap = () => {
   map = drawMap(mapboxgl, map);
 
   map.once("style.load", () => {
@@ -236,19 +235,21 @@ window.addEventListener("DOMContentLoaded", () => {
         ]);
       }
     });
-    whenMapAndDataReady(ddb, map);
   });
+};
+
+// Reload data every five minutes
+const FIVE_MINUTES_IN_MS = 300000;
+const recursiveDataLoad = () => {
+  pageDraws++;
   loadDataOnPage();
-
-  // Reload data every five minutes
-  const FIVE_MINUTES_IN_MS = 300000;
-  const recursiveDataLoad = () => {
-    pageDraws++;
-    loadDataOnPage();
-    setTimeout(recursiveDataLoad, FIVE_MINUTES_IN_MS);
-  };
-
   setTimeout(recursiveDataLoad, FIVE_MINUTES_IN_MS);
+};
 
+window.addEventListener("DOMContentLoaded", () => {
+  initDataTranslate(setLang);
+  initMap();
+  loadDataOnPage();
+  setTimeout(recursiveDataLoad, FIVE_MINUTES_IN_MS);
   startReloadTimer();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -157,8 +157,9 @@ const initDataTranslate = () => {
     });
 
   // Language selector event handler
-  if (document.querySelectorAll("[data-lang-picker]")) {
-    document.querySelectorAll("[data-lang-picker]").forEach((pick) => {
+  const langPickers = document.querySelectorAll("[data-lang-picker]");
+  if (langPickers) {
+    langPickers.forEach((pick) => {
       pick.addEventListener("click", (e) => {
         e.preventDefault();
         setLang(e.target.dataset.langPicker);

--- a/src/index.js
+++ b/src/index.js
@@ -255,14 +255,6 @@ document.addEventListener("covid19japan-redraw", () => {
     callIfUpdated(() => drawLastUpdated(ddb.lastUpdated, LANG));
     callIfUpdated(() => drawPageTitleCount(ddb.totals.confirmed));
     callIfUpdated(() => {
-      prefectureTrendCharts = drawPrefectureTable(
-        ddb.prefectures,
-        ddb.totals,
-        prefectureTrendCharts
-      );
-    });
-    callIfUpdated(() => drawTravelRestrictions(ddb));
-    callIfUpdated(() => {
       trendChart = drawTrendChart(ddb.trend, trendChart);
     });
     callIfUpdated(() => {
@@ -278,6 +270,14 @@ document.addEventListener("covid19japan-redraw", () => {
         LANG
       );
     });
+    callIfUpdated(() => {
+      prefectureTrendCharts = drawPrefectureTable(
+        ddb.prefectures,
+        ddb.totals,
+        prefectureTrendCharts
+      );
+    });
+    callIfUpdated(() => drawTravelRestrictions(ddb));
   }
 
   whenMapAndDataReady(ddb, map);

--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ const startReloadTimer = () => {
   setTimeout(() => location.reload(), reloadInterval * 60 * 60 * 1000);
 };
 
-window.onload = () => {
+window.addEventListener("DOMContentLoaded", () => {
   initDataTranslate(setLang);
   map = drawMap(mapboxgl, map);
 
@@ -251,4 +251,4 @@ window.onload = () => {
   setTimeout(recursiveDataLoad, FIVE_MINUTES_IN_MS);
 
   startReloadTimer();
-};
+});

--- a/src/index.js
+++ b/src/index.js
@@ -243,9 +243,9 @@ const recursiveDataLoad = () => {
 
 // Call only if ddb is updated.
 // Uses a setTimeout to queue a new macrotask
-const callIfUpdated = (callback) => {
+const callIfUpdated = (callback, delay = 0) => {
   if (ddb.isUpdated()) {
-    setTimeout(callback, 0);
+    setTimeout(callback, delay);
   }
 };
 
@@ -269,18 +269,18 @@ document.addEventListener("covid19japan-redraw", () => {
         prefectureTrajectoryChart,
         LANG
       );
-    });
+    }, 32);
     callIfUpdated(() => {
       prefectureTrendCharts = drawPrefectureTable(
         ddb.prefectures,
         ddb.totals,
         prefectureTrendCharts
       );
-    });
+    }, 32);
     callIfUpdated(() => drawTravelRestrictions(ddb));
   }
 
-  whenMapAndDataReady(ddb, map);
+  callIfUpdated(() => whenMapAndDataReady(ddb, map));
 });
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
@reustle @liquidx Here's a first attempt at performance improvement for https://github.com/reustle/covid19japan/issues/237  through changes in timing and taking advantage of how the JS event loop runs in a browser.

## Before

![Screen Shot 2020-04-18 at 11 01 49 PM](https://user-images.githubusercontent.com/3714/79639888-5bfdf100-81c9-11ea-91dc-c7280473e47c.png)

This is a capture of a run through the profiler on `master` using a local environment. My observations were:

* Most of the work doesn't start until the `load` event. Lots of idle time prior to that.
* There's a huge macrotask (labeled Task) after `load` where all the action happens. This blocks all rendering because the event loop is stuck on that task and can't do anything else. The browser won't render until the task completes

I also noticed that `drawPrefectureTable` was called twice because of i18n.

## Approach

So, my basic strategy was:
1. Trigger on `DOMContentLoaded` rather than `Load`. `Load` is actually late because it waits for stuff like images as well. For JS, you only need the DOM to be ready. This saves us some time
2. Split up the big macrotask so that other events can be processed, and hopefully the browser can render parts of the page rather than waiting until the whole thing is finished.
  * This is achieved by using `setTimeout` so that each logical render is a separate macro task in the event loop task queue. 
3. Reduce the coupling between data load and render as much as possible.
4. Try to avoid drawing when there is no data, or no update.


## Result

![Screen Shot 2020-04-18 at 10 53 51 PM](https://user-images.githubusercontent.com/3714/79640035-50f79080-81ca-11ea-8f42-9edbdbe11540.png)

(If you look closely, you may notice that the total length of this profile snapshot is actually longer. Ignore that: it's just a measurement artifact)

* Data load happens earlier now, at DCL
* No longer have the unnecessary double render of the trajectory chart
* The slowest charts below the load will render later, so that first view (the numbers) should load a little faster now.
* When data loads, it *should* avoid unnecessary redraws. In the long run, this should hopefully mitigate the memory issues somewhat.


## Further thoughts

Unfortunately, this change doesn't actually reduce the total CPU/memory burden too much. My understanding of the profiler results tell me that:
* c3.js/d3.js is very intensive. If we really want to have interactive charts, they may be worth putting on a separate page. It's where all the CPU time is going.
* data pre-processing probably won't help too much. It will be good for clarity of the code, which will again make it easier to change charting libraries.
* For the prefecture table, I suspect there's some layout thrashing going on. One approach could be to actually build the inner html string for the entire table and insert in one go. Then, draw the trend charts. This will reduce the number of times we write to the DOM and speed it up a bit.
 
## Does it feel faster?

Please try out the staging version and see if it feels better. Rather than my profiler screenshots, I think that actually trying it out should be the ultimate way to judge whether this is an actual performance improvement.