### PR TITLE
Use deprecated event APIs when Event not available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,14 @@ const loadDataOnPage = () => {
       ddb.totalsDiff = newTotals[1];
       ddb.trend = jsonData.daily;
 
-      let event = new Event("covid19japan-redraw");
+      let event;
+      if (typeof Event === "function") {
+        event = new Event("covid19japan-redraw");
+      } else {
+        // Fall back to deprecated methods for IE11 etc
+        event = document.createEvent("Event");
+        event.initEvent("covid19japan-redraw");
+      }
       document.dispatchEvent(event);
     }
   });


### PR DESCRIPTION
Resolves: https://sentry.io/organizations/reustle-co/issues/1620525134/?project=2967034&query=is%3Aunresolved

Thanks to @liquidx for the tipoff.

Uses the deprecated [createEvent](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent) when the modern Event is unavailable. 