### PR TITLE
initEvent requires all 3 arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,7 @@ const loadDataOnPage = () => {
       } else {
         // Fall back to deprecated methods for IE11 etc
         event = document.createEvent("Event");
-        event.initEvent("covid19japan-redraw");
+        event.initEvent("covid19japan-redraw", true, false);
       }
       document.dispatchEvent(event);
     }


### PR DESCRIPTION
// Please tag @reustle in your newly created PR

https://sentry.io/organizations/reustle-co/issues/1626417201/?project=2967034&query=is%3Aunresolved

Oops, turns out that [initEvent](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent) had required arguments 🤦 

(The Sentry issue highlights the line for `createEvent`, but that only has one argument. It's `initEvent` that needs the args)

Should switch to a proper polyfill. Will do that later once I find one.

cc: @liquidx 