### PR TITLE
Custom event polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2716,6 +2716,11 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "custom-event-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "c3": "^0.7.15",
     "classlist-polyfill": "^1.2.0",
     "core-js": "^3.6.4",
+    "custom-event-polyfill": "^1.0.7",
     "d3": "^5.15.0",
     "date-fns": "^2.11.1",
     "express": "^4.17.1",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import "core-js/stable";
 import "whatwg-fetch";
 import "classlist-polyfill";
+import "custom-event-polyfill";
 
 // Add all non-polyfill deps below.
 import i18next from "i18next";
@@ -205,14 +206,7 @@ const loadDataOnPage = () => {
       ddb.totalsDiff = newTotals[1];
       ddb.trend = jsonData.daily;
 
-      let event;
-      if (typeof Event === "function") {
-        event = new Event("covid19japan-redraw");
-      } else {
-        // Fall back to deprecated methods for IE11 etc
-        event = document.createEvent("Event");
-        event.initEvent("covid19japan-redraw");
-      }
+      const event = new CustomEvent("covid19japan-redraw");
       document.dispatchEvent(event);
     }
   });


### PR DESCRIPTION
Followup to #245 #246 

I wasn't able to quickly find a polyfill for the plain Event constructor, but was able to find one for CustomEvent. [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) is still appropriate, even if we don't use the optional dictionary argument.

Polyfill source: https://github.com/kumarharsh/custom-event-polyfill/blob/master/polyfill.js (it's a quick read)
NPM: https://www.npmjs.com/package/custom-event-polyfill
