### PR TITLE
Ignore errors from some extensions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,16 @@
       Sentry.init({
         dsn: 'https://1c7127f5f5b2432d99a5bf44a3b74d08@sentry.io/2967034',
         debug: false,
+	blacklistUrls: [
+	  // Chrome extensions
+	  /extensions\//i,
+	  /^chrome:\/\//i,
+	],
+        ignoreErrors: [
+	  // Ignore Google Translate Chrome extension errors.
+	  // See: https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca
+	  "a[b].target.className.indexOf is not a function",
+	],
         integrations: [
           new Sentry.Integrations.CaptureConsole({
             levels: ['error']


### PR DESCRIPTION
We can't do anything about errors originating in browser extensions.
In particular, an error from Google Translate is particularly common,
so it has been ignored explicitly.

- The relevant error: https://sentry.io/organizations/reustle-co/issues/1578957571/?project=2967034&query=is%3Aunresolved
    - 242k events so far!
- Description of cause: https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca
- Suggested solution: https://github.com/getsentry/sentry/pull/10153#issuecomment-437292476
    * Note that the linked PR was ultimately reverted. However, as noted in the comments, the specified ignore string works if it is added to the ignoreErrors section of Sentry's init.
* See the "Decluttering Sentry" section for furthe details: https://docs.sentry.io/platforms/javascript/


