### PR TITLE
Update Prefecture Table to show yesterday and today's increase.

### DIFF
--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -117,24 +117,17 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       }
 
       const thisPrefecture = matchingPrefectures[0];
-      let increment = 0;
-
       if (typeof thisPrefecture === "undefined") {
         return; // This happens if prefecture doesn't have any stats (e.g. Iwate)
       }
 
-      if (thisPrefecture.dailyConfirmedCount) {
-        increment =
-          thisPrefecture.dailyConfirmedCount[
-            thisPrefecture.dailyConfirmedCount.length - 1
-          ];
-      }
-
+      const increment = thisPrefecture[0].newlyConfirmed;
       if (increment > 0) {
         var popupIncrementSpan = `<span class='popup-increment'>(+${increment})</span>`;
       } else {
         var popupIncrementSpan = "";
       }
+      
       const name = thisPrefecture.name;
       const confirmed = thisPrefecture.confirmed;
       const deaths = thisPrefecture.deaths;

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -112,7 +112,7 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
         return p.name === feature.properties.NAME_1;
       });
 
-      if (!matchingPrefectures || !matchingPrefectures.length < 1) {
+      if (!matchingPrefectures || matchingPrefectures.length < 1) {
         return;
       }
 

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -112,22 +112,17 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
         return p.name === feature.properties.NAME_1;
       });
 
-      if (!matchingPrefectures || matchingPrefectures.length < 1) {
+      if (!matchingPrefectures || !matchingPrefectures.length < 1) {
         return;
       }
 
       const thisPrefecture = matchingPrefectures[0];
-      if (typeof thisPrefecture === "undefined") {
-        return; // This happens if prefecture doesn't have any stats (e.g. Iwate)
-      }
-
-      const increment = thisPrefecture[0].newlyConfirmed;
+      const increment = thisPrefecture.newlyConfirmed;
       if (increment > 0) {
         var popupIncrementSpan = `<span class='popup-increment'>(+${increment})</span>`;
       } else {
         var popupIncrementSpan = "";
       }
-      
       const name = thisPrefecture.name;
       const confirmed = thisPrefecture.confirmed;
       const deaths = thisPrefecture.deaths;

--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -117,12 +117,17 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
       }
 
       const thisPrefecture = matchingPrefectures[0];
-      const increment = thisPrefecture.newlyConfirmed;
+      if (typeof thisPrefecture === "undefined") {
+        return; // This happens if prefecture doesn't have any stats (e.g. Iwate)
+      }
+
+      let increment = thisPrefecture.newlyConfirmed;
       if (increment > 0) {
         var popupIncrementSpan = `<span class='popup-increment'>(+${increment})</span>`;
       } else {
         var popupIncrementSpan = "";
       }
+
       const name = thisPrefecture.name;
       const confirmed = thisPrefecture.confirmed;
       const deaths = thisPrefecture.deaths;

--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -29,6 +29,7 @@ const drawPrefectureTrend = (
   }
   prefectureTrendCharts[elementId] = c3.generate({
     bindto: elementId,
+    padding: { left: 0, right: 0, top: 0, bottom: 0 },
     interaction: { enabled: false },
     data: {
       type: "bar",
@@ -44,7 +45,6 @@ const drawPrefectureTrend = (
         show: false,
         min: 0,
         padding: { left: 0, right: 0 },
-        padding: 5,
       },
       y: {
         show: false,
@@ -54,9 +54,9 @@ const drawPrefectureTrend = (
       },
     },
     size: {
-      height: 40,
+      height: 30,
+      width: 120,
     },
-    padding: { left: 0, right: 0, top: 0, bottom: 0 },
     legend: { show: false },
     tooltip: { show: false },
     point: { show: false },
@@ -118,11 +118,13 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
     }
 
     let incrementString = "";
+    let todayConfirmedString = "";
+    let yesterdayConfirmedString = "";
     if (pref.newlyConfirmed > 0) {
-      incrementString += `&nbsp;<span class='increment'>+${pref.newlyConfirmed}</span>`;
+      todayConfirmedString = `(&nbsp;+${pref.newlyConfirmed}&nbsp;)`;
     }
     if (pref.yesterdayConfirmed > 0) {
-      incrementString += `&nbsp;<span class='increment yesterday'>+${pref.yesterdayConfirmed}</span>`;
+      yesterdayConfirmedString = `(&nbsp;+${pref.yesterdayConfirmed}&nbsp;)`;
     }
 
     if (pref.name == "Unspecified") {
@@ -130,8 +132,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="unspecified">${i18next.t(
           "unspecified"
         )}</td>
-        <td class="count">${pref.confirmed} ${incrementString}</td>
         <td class="trend"><div id="Unspecified-trend"></div></td>
+        <td class="count confirmed">${pref.confirmed}</td>
+        <td class="delta">
+          <div class="increment">
+            <span class="today">${todayConfirmedString}</span>
+            <span class="yesterday">${yesterdayConfirmedString}</span>
+          </div>
+        </td>
         <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
         <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
         </tr>`;
@@ -152,8 +160,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="port-of-entry">${i18next.t(
           "port-of-entry"
         )}</td>
-        <td class="count">${pref.confirmed} ${incrementString}</td>
         <td class="trend"><div id="PortOfEntry-trend"></div></td>
+        <td class="count confirmed">${pref.confirmed} ${incrementString}</td>
+        <td class="delta">
+          <div class="increment">
+            <span class="today">${todayConfirmedString}</span>
+            <span class="yesterday">${yesterdayConfirmedString}</span>
+          </div>
+        </td>
         <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
         <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
         </tr>`;
@@ -174,8 +188,14 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="prefectures.${pref.name}">${i18next.t(
         "prefectures." + pref.name
       )}</td>
-        <td class="count">${pref.confirmed} ${incrementString}</td>
         <td class="trend"><div id="${pref.name}-trend"></div></td>
+        <td class="count confirmed">${pref.confirmed} ${incrementString}</td>
+        <td class="delta">
+          <div class="increment">
+            <span class="today">${todayConfirmedString}</span>
+            <span class="yesterday">${yesterdayConfirmedString}</span>
+          </div>
+       </td>
         <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
         <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
       `;
@@ -193,8 +213,8 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
 
   dataTableFoot.innerHTML = `<tr class='totals'>
         <td data-i18n="total">${i18next.t("total")}</td>
-        <td class="count">${totals.confirmed}</td>
         <td class="trend"></td>
+        <td class="count" colspan="3">${totals.confirmed}</td>
         <td class="count recovered">${totals.recovered}</td>
         <td class="count deceased">${totals.deceased}</td>
         </tr>`;

--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -36,26 +36,27 @@ const drawPrefectureTrend = (
       colors: { confirmed: COLOR_CONFIRMED },
     },
     bar: {
-      width: { ratio: 0.65 },
+      width: { ratio: 1 },
       zerobased: true,
     },
     axis: {
       x: {
         show: false,
         min: 0,
+        padding: { left: 0, right: 0 },
         padding: 5,
       },
       y: {
         show: false,
         min: 0,
         max: yMax,
-        padding: 1,
+        padding: { top: 0, bottom: 0 },
       },
     },
     size: {
       height: 40,
     },
-
+    padding: { left: 0, right: 0, top: 0, bottom: 0 },
     legend: { show: false },
     tooltip: { show: false },
     point: { show: false },
@@ -108,8 +109,6 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
     pref.recovered = pref.recovered ? parseInt(pref.recovered) : 0;
     // TODO change to deceased
     pref.deceased = pref.deaths ? parseInt(pref.deaths) : 0;
-    pref.active =
-      pref.confirmed - ((pref.recovered || 0) + (pref.deceased || 0));
   });
 
   // Iterate through and render table rows
@@ -118,11 +117,12 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
       return;
     }
 
-    let increment =
-      pref.dailyConfirmedCount[pref.dailyConfirmedCount.length - 1];
     let incrementString = "";
-    if (increment > 0) {
-      incrementString = `<span class='increment'>(+${increment})</span>`;
+    if (pref.newlyConfirmed > 0) {
+      incrementString += `&nbsp;<span class='increment'>+${pref.newlyConfirmed}</span>`;
+    }
+    if (pref.yesterdayConfirmed > 0) {
+      incrementString += `&nbsp;<span class='increment yesterday'>+${pref.yesterdayConfirmed}</span>`;
     }
 
     if (pref.name == "Unspecified") {
@@ -130,11 +130,10 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="unspecified">${i18next.t(
           "unspecified"
         )}</td>
-        <td class="trend"><div id="Unspecified-trend"></div></td>
         <td class="count">${pref.confirmed} ${incrementString}</td>
-        <td class="count">${pref.recovered ? pref.recovered : ""}</td>
-        <td class="count">${pref.deceased ? pref.deceased : ""}</td>
-        <td class="count">${pref.active || ""}</td>
+        <td class="trend"><div id="Unspecified-trend"></div></td>
+        <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
+        <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
         </tr>`;
       enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
@@ -153,11 +152,10 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="port-of-entry">${i18next.t(
           "port-of-entry"
         )}</td>
-        <td class="trend"><div id="PortOfEntry-trend"></div></td>
         <td class="count">${pref.confirmed} ${incrementString}</td>
-        <td class="count">${pref.recovered ? pref.recovered : ""}</td>
-        <td class="count">${pref.deceased ? pref.deceased : ""}</td>
-        <td class="count">${pref.active || ""}</td>
+        <td class="trend"><div id="PortOfEntry-trend"></div></td>
+        <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
+        <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
         </tr>`;
       enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
@@ -176,11 +174,10 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
         <td class="prefecture" data-i18n="prefectures.${pref.name}">${i18next.t(
         "prefectures." + pref.name
       )}</td>
-        <td class="trend"><div id="${pref.name}-trend"></div></td>
         <td class="count">${pref.confirmed} ${incrementString}</td>
-        <td class="count">${pref.recovered ? pref.recovered : ""}</td>
-        <td class="count">${pref.deceased ? pref.deceased : ""}</td>
-        <td class="count">${pref.active || ""}</td>
+        <td class="trend"><div id="${pref.name}-trend"></div></td>
+        <td class="count recovered">${pref.recovered ? pref.recovered : ""}</td>
+        <td class="count deceased">${pref.deceased ? pref.deceased : ""}</td>
       `;
       enqueueMacrotask(() => {
         prefectureTrendCharts = drawPrefectureTrend(
@@ -196,13 +193,10 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
 
   dataTableFoot.innerHTML = `<tr class='totals'>
         <td data-i18n="total">${i18next.t("total")}</td>
-        <td class="trend"></td>
         <td class="count">${totals.confirmed}</td>
-        <td class="count">${totals.recovered}</td>
-        <td class="count">${totals.deceased}</td>
-        <td class="count">${
-          totals.confirmed - totals.recovered - totals.deceased
-        }</td>
+        <td class="trend"></td>
+        <td class="count recovered">${totals.recovered}</td>
+        <td class="count deceased">${totals.deceased}</td>
         </tr>`;
 
   return prefectureTrendCharts;

--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -214,7 +214,7 @@ const drawPrefectureTable = (prefectures, totals, prefectureTrendCharts) => {
   dataTableFoot.innerHTML = `<tr class='totals'>
         <td data-i18n="total">${i18next.t("total")}</td>
         <td class="trend"></td>
-        <td class="count" colspan="3">${totals.confirmed}</td>
+        <td class="count" colspan="2">${totals.confirmed}</td>
         <td class="count recovered">${totals.recovered}</td>
         <td class="count deceased">${totals.deceased}</td>
         </tr>`;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -32,8 +32,8 @@
   "total": "Total",
   "port-of-entry": "Port of Entry",
   "unspecified": "Unspecified",
-  "increment-today": "+Today",
-  "increment-yesterday": "+Yesterday",
+  "increment-today": "(Today)",
+  "increment-yesterday": "(Yesterday)",
   "prefectures": {
     "Aichi": "Aichi",
     "Akita": "Akita",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -32,6 +32,8 @@
   "total": "Total",
   "port-of-entry": "Port of Entry",
   "unspecified": "Unspecified",
+  "increment-today": "+Today",
+  "increment-yesterday": "+Yesterday",
   "prefectures": {
     "Aichi": "Aichi",
     "Akita": "Akita",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -32,6 +32,8 @@
   "total": "計",
   "port-of-entry": "入国港",
   "unspecified": "不明",
+  "increment-today": "+今日",
+  "increment-yesterday": "+昨日",
   "prefectures": {
     "Aichi": "愛知県",
     "Akita": "秋田県",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -32,8 +32,8 @@
   "total": "計",
   "port-of-entry": "入国港",
   "unspecified": "不明",
-  "increment-today": "+今日",
-  "increment-yesterday": "+昨日",
+  "increment-today": "(今日)",
+  "increment-yesterday": "(昨日)",
   "prefectures": {
     "Aichi": "愛知県",
     "Akita": "秋田県",

--- a/src/index.html
+++ b/src/index.html
@@ -170,11 +170,15 @@
       <thead>
         <tr>
           <th data-i18n="prefecture" class="prefecture">Prefecture</th>
-          <th class="trend" colspan="2">
+          <th class="trend"></th>
+          <th class="" colspan="2">
             <span data-i18n="confirmed">Confirmed</span> 
-            <span class="increment"><span data-i18n="increment-today">＋Today</span>
-            <span class="increment yesterday"><span data-i18n="increment-yesterday">＋Yesterday</span></span>
+            <div class="increment">
+              <span class="delta today"><span data-i18n="increment-today">(Today)</span>
+              <span class="delta yesterday"><span data-i18n="increment-yesterday">(Yesterday)</span></span>
+            </div>
           </th>
+
           <th data-i18n="recovered" class="recovered">Recovered</th>
           <th data-i18n="deaths" class="deceased">Deaths</th>
         </tr>

--- a/src/index.html
+++ b/src/index.html
@@ -170,11 +170,13 @@
       <thead>
         <tr>
           <th data-i18n="prefecture" class="prefecture">Prefecture</th>
-          <th class="trend"><div id="sparkline-chart"></div></th>
-          <th data-i18n="confirmed">Confirmed</th>
-          <th data-i18n="recovered">Recovered</th>
-          <th data-i18n="deaths">Deaths</th>
-          <th data-i18n="active">Active</th>
+          <th class="trend" colspan="2">
+            <span data-i18n="confirmed">Confirmed</span> 
+            <span class="increment"><span data-i18n="increment-today">＋Today</span>
+            <span class="increment yesterday"><span data-i18n="increment-yesterday">＋Yesterday</span></span>
+          </th>
+          <th data-i18n="recovered" class="recovered">Recovered</th>
+          <th data-i18n="deaths" class="deceased">Deaths</th>
         </tr>
       </thead>
       <tbody>

--- a/src/index.scss
+++ b/src/index.scss
@@ -259,10 +259,6 @@ table {
     width: 2em;
   }
 
-  th.recovered, td.recovered {
-    color: $color-recovered;
-  }
-
   div.increment {
     display: block;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,6 +3,9 @@
 
 
 $primary-black: #000a12;
+$color-confirmed: rgb(244,67,52);
+$color-recovered: rgb(24,118,211);
+$color-deceased:  rgb(54,72,79);
 
 body {
   margin: 0px;
@@ -93,7 +96,7 @@ h1 {
       font-weight: 700;
     }
     .value {
-      font-size: 32px;
+      font-size: 28px;
       font-weight: 800;
       margin-bottom: 14px;
     }
@@ -104,13 +107,13 @@ h1 {
   }
 
   #kpi-confirmed {
-    color: rgb(244,67,52);
+    color: $color-confirmed;
   }
   #kpi-recovered {
-    color: rgb(24,118,211);
+    color: $color-recovered;
   }
   #kpi-deceased {
-    color: rgb(54,72,79);
+    color: $color-deceased;
   }
   #kpi-critical {
     color:  rgb(114,4,5);
@@ -130,7 +133,7 @@ h1 {
   }
 
   .kpi-metrics {
-    font-size: 28px;
+    font-size: 24px;
    font-weight: 800;
   }
 
@@ -204,7 +207,6 @@ table {
 
   tfoot tr {
     background-color: rgb(235, 238, 239);
-
   }
 
   th {
@@ -212,10 +214,10 @@ table {
     font-size: 11px;
     min-width: 7em;
   }
-  td {
+  th, td {
     padding: 5px 0px;
   }
-  td:first-child {
+  th.prefecture, td.prefecture {
     padding: 5px;
   }
   .totals {
@@ -234,18 +236,26 @@ table {
 
 
   th.trend, td.trend {
-    width: 180px;
-    min-width: 180px;
-    max-width: 240px;
-    padding: 0 4px;
+    min-width: 120px;
+    max-width: 180px;
   }
 
   th.count, td.count {
-    width: 7em;
+    min-width: 3em;
+    line-height: 1em;
+  }
+
+  th.recovered, td.recovered {
+    color: $color-recovered;
   }
 
   span.increment {
-    color: rgb(244,67,54);
+    color: $color-confirmed;
+    font-size: 10px;
+  }
+
+  span.increment.yesterday {
+    color: rgb(128, 122, 122);
     font-size: 10px;
   }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -217,7 +217,7 @@ table {
 
   th, td {
     padding: 5px 5px;
-    line-height: 1.0em;
+    line-height: 1.2em;
   }
 
   thead th {

--- a/src/index.scss
+++ b/src/index.scss
@@ -127,7 +127,6 @@ h1 {
 
 
   table {
-    text-align: center;
     width: 100%;
     border-spacing: 0px 10px;
   }
@@ -213,13 +212,29 @@ table {
     text-align: left;
     font-size: 11px;
     min-width: 7em;
+    vertical-align: baseline;
   }
+
   th, td {
-    padding: 5px 0px;
+    padding: 5px 5px;
+    line-height: 1.0em;
   }
-  th.prefecture, td.prefecture {
-    padding: 5px;
+
+  thead th {
+    min-height: 40px;
+    border-bottom: 2px solid rgb(219, 219, 219);
   }
+
+  thead tr {
+    padding-bottom: 10px;
+  }
+
+  tbody td {
+    vertical-align: middle;
+    height: 40px;
+    min-height: 40px;
+  }
+
   .totals {
     font-weight: bold;
   }
@@ -229,34 +244,43 @@ table {
   }
 
   th.prefecture, td.prefecture {
+    padding: 5px;
     min-width: 60px;
     max-width: 100px;
     white-space: nowrap;
   }
 
-
   th.trend, td.trend {
-    min-width: 120px;
-    max-width: 180px;
+    width: 120px;
+    padding: 0 10px;
   }
 
-  th.count, td.count {
-    min-width: 3em;
-    line-height: 1em;
+  td.confirmed {
+    width: 2em;
   }
 
   th.recovered, td.recovered {
     color: $color-recovered;
   }
 
-  span.increment {
+  div.increment {
+    display: block;
+  }
+
+  .today {
     color: $color-confirmed;
     font-size: 10px;
   }
 
-  span.increment.yesterday {
+  .yesterday {
     color: rgb(128, 122, 122);
     font-size: 10px;
+  }
+
+  td.delta {
+    width: 40px;
+    padding-left: 2px;
+    text-align: left;
   }
 
 }


### PR DESCRIPTION
Removes the active column since this tended to be roughly the same as active because so little people have recovered.

Show both yesterday and today's increase makes it more relevant during the day when prefectures have not all reported their counts but you want to know what happened on the previous day.