### PR TITLE
Avoid initializing mapbox if webgl is not supported.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -129,18 +129,20 @@
     </div>
   </section>
 
-  <a name="map"></a>
-  <div class="center-offset">
-    <h4><span data-i18n="covid-19" class="embed-show">COVID-19</span> <span data-i18n="outbreak-map">Outbreak Map</span></h4>
-  </div>
-  <section id="map-legend">
-    <div><span class="one">▉</span> 1-50 <span data-i18n="cases">cases</span></div>
-    <div><span class="two">▉</span> 51-100 <span data-i18n="cases">cases</span></div>
-    <div><span class="three">▉</span> 101-200 <span data-i18n="cases">cases</span></div>
-    <div><span class="four">▉</span> 201+ <span data-i18n="cases">cases</span></div>
-  </section>
-  <div id="map-container"></div>
-  <p class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></p>
+  <section id="outbreak-map-container">
+    <a name="map"></a>
+    <div class="center-offset">
+      <h4><span data-i18n="covid-19" class="embed-show">COVID-19</span> <span data-i18n="outbreak-map">Outbreak Map</span></h4>
+    </div>
+    <section id="map-legend">
+      <div><span class="one">▉</span> 1-50 <span data-i18n="cases">cases</span></div>
+      <div><span class="two">▉</span> 51-100 <span data-i18n="cases">cases</span></div>
+      <div><span class="three">▉</span> 101-200 <span data-i18n="cases">cases</span></div>
+      <div><span class="four">▉</span> 201+ <span data-i18n="cases">cases</span></div>
+    </section>
+    <div id="map-container"></div>
+    <p class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></p>
+  </section>    
 
   <section id="trend-chart-container" class="embed-hide">
     <h4 data-i18n="outbreak-spread-trend">Outbreak Spread Trend</h4>

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ const setLang = (lng) => {
   i18next.changeLanguage(LANG).then(() => {
     localize("html");
     // Update the map
-    if (styleLoaded) {
+    if (styleLoaded && map) {
       map.getStyle().layers.forEach((thisLayer) => {
         if (thisLayer.type == "symbol") {
           map.setLayoutProperty(thisLayer.id, "text-field", [
@@ -187,7 +187,7 @@ let jsonData = undefined;
 const whenMapAndDataReady = (ddb, map) => {
   // This runs drawMapPref only when
   // both style and json data are ready
-  if (!styleLoaded || !jsonData) {
+  if (!styleLoaded || !jsonData || !map) {
     return;
   }
   drawMapPrefectures(pageDraws, ddb, map);
@@ -218,20 +218,30 @@ const startReloadTimer = () => {
 };
 
 const initMap = () => {
-  map = drawMap(mapboxgl, map);
+  if (mapboxgl.supported()) {
+    map = drawMap(mapboxgl, map);
+  } else {
+    // Hide the outbreak map.
+    let mapContainer = document.querySelector("#outbreak-map-container");
+    if (mapContainer) {
+      mapContainer.style.display = "none";
+    }
+  }
 
-  map.once("style.load", () => {
-    styleLoaded = true;
+  if (map) {
+    map.once("style.load", () => {
+      styleLoaded = true;
 
-    map.getStyle().layers.forEach((thisLayer) => {
-      if (thisLayer.type == "symbol") {
-        map.setLayoutProperty(thisLayer.id, "text-field", [
-          "get",
-          `name_${LANG}`,
-        ]);
-      }
+      map.getStyle().layers.forEach((thisLayer) => {
+        if (thisLayer.type == "symbol") {
+          map.setLayoutProperty(thisLayer.id, "text-field", [
+            "get",
+            `name_${LANG}`,
+          ]);
+        }
+      });
     });
-  });
+  }
 };
 
 // Reload data every five minutes


### PR DESCRIPTION
Fix a large class of errors we get by testing for webGL support before trying to initialize mapbox.