### PR TITLE
Fix display of cruise ship counts on Prefecture table

### DIFF
--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -147,7 +147,6 @@ const drawPrefectureTable = (prefectures, totals) => {
     let isPseudoPrefecture = pseudoPrefectures[pref.name];
     if (isPseudoPrefecture) {
       if (isPseudoPrefecture.stringId) {
-        console.log(isPseudoPrefecture.stringId, pref.name);
         let stringId = isPseudoPrefecture.stringId;
         let trendElementId = `${isPseudoPrefecture.className}-trend`;
         let row = document.createElement("tr");

--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -14,7 +14,9 @@ const drawPrefectureTrajectoryChart = (
 ) => {
   const minimumConfirmed = 100;
   const filteredPrefectures = filter(prefectures, (prefecture) => {
-    return prefecture.confirmed >= minimumConfirmed;
+    return (
+      prefecture.confirmed >= minimumConfirmed && !prefecture.pseudoPrefecture
+    );
   });
   const trajectories = reduce(
     filteredPrefectures,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,12 +30,16 @@
   "other-limitations": "Other Limitations:",
   "provisional": "Provisional",
   "total": "Total",
-  "port-of-entry": "Port of Entry",
-  "unspecified": "Unspecified",
   "increment-today": "(Today)",
   "increment-yesterday": "(Yesterday)",
   "daily": "Daily",
   "7-day-average": "7-day average",
+  "pseudo-prefectures": {
+    "port-of-entry": "Port of Entry",
+    "unspecified": "Unspecified",
+    "diamond-princess": "Diamond Princess Cruise Ship",
+    "nagasaki-cruise": "Nagasaki Cruise Ship"
+  },
   "prefectures": {
     "Aichi": "Aichi",
     "Akita": "Akita",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -30,12 +30,16 @@
   "other-limitations": "その他",
   "provisional": "暫定",
   "total": "計",
-  "port-of-entry": "入国港",
-  "unspecified": "不明",
   "increment-today": "(今日)",
   "increment-yesterday": "(昨日)",
   "daily": "毎日の数",
   "7-day-average": "7日間の平均",
+  "pseudo-prefectures": {
+    "port-of-entry": "入国港",
+    "unspecified": "不明",
+    "diamond-princess": "ダイヤモンド・プリンセス",
+    "nagasaki-cruise": "長崎のクルーズ船"
+  },
   "prefectures": {
     "Aichi": "愛知県",
     "Akita": "秋田県",

--- a/src/index.js
+++ b/src/index.js
@@ -289,11 +289,7 @@ document.addEventListener("covid19japan-redraw", () => {
       );
     }, 32);
     callIfUpdated(() => {
-      prefectureTrendCharts = drawPrefectureTable(
-        ddb.prefectures,
-        ddb.totals,
-        prefectureTrendCharts
-      );
+      drawPrefectureTable(ddb.prefectures, ddb.totals);
     }, 32);
     callIfUpdated(() => drawTravelRestrictions(ddb));
   }


### PR DESCRIPTION
Removes some unused variables with cleaning up trend graph that probably got added when the huge index.js got split. 

Adds tests to ignore pseudoPrefectures for the trajectory graph and slightly better handling of the special rows in the prefecture table now that we have 4 instead of 2.