### PR TITLE
Reduce d3 dependencies, remove CNAME from build

### DIFF
--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -1,5 +1,5 @@
 import * as c3 from "c3";
-import * as d3 from "d3";
+import { color as d3_color } from "d3-color";
 import i18next from "i18next";
 import { format as dateFormat } from "date-fns";
 import { enUS, ja } from "date-fns/locale";
@@ -56,7 +56,7 @@ const drawTrendChart = (sheetTrend, trendChart, lang) => {
       x: "Date",
       color: (color, d) => {
         if (d && d.index === cols.Date.length - 2) {
-          const newColor = d3.color(color);
+          const newColor = d3_color(color);
           newColor.opacity = 0.6;
           return newColor;
         } else {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,78 +1,70 @@
-
-const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
-  mode: 'development',  
-  entry: { 
-    index: ['./src/index.js', './src/index.scss']
+  mode: "development",
+  entry: {
+    index: ["./src/index.js", "./src/index.scss"],
   },
   output: {
-    path: path.resolve(__dirname, 'docs'),
-    filename: '[name].js',
-    publicPath: '/'
+    path: path.resolve(__dirname, "docs"),
+    filename: "[name].js",
+    publicPath: "/",
   },
 
   devServer: {
-    contentBase: './docs'
+    contentBase: "./docs",
   },
 
   plugins: [
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
-      filename: 'index.html',
-      template: 'src/index.html',
-      chunks: ['index']
+      filename: "index.html",
+      template: "src/index.html",
+      chunks: ["index"],
     }),
     new HtmlWebpackPlugin({
-      bodyClass: 'embed',
-      filename: 'embed.html',
-      template: 'src/index.html',
-      chunks: ['index']
+      bodyClass: "embed",
+      filename: "embed.html",
+      template: "src/index.html",
+      chunks: ["index"],
     }),
-    new CopyPlugin([
-      { from: 'CNAME', to: '.', flatten: false }
-    ]),
-    new CopyPlugin([
-      { from: 'static/**', to: '.', flatten: false }
-    ]),
+    new CopyPlugin([{ from: "static/**", to: ".", flatten: false }]),
     new MiniCssExtractPlugin({
-      filename: '[name].css'
-    })  
+      filename: "[name].css",
+    }),
   ],
   module: {
-    rules:[
+    rules: [
       {
-        test:  /\.(png|svg|jpg|gif|ico|geojson)$/,
-        use: [
-          'file-loader'
-        ]
+        test: /\.(png|svg|jpg|gif|ico|geojson)$/,
+        use: ["file-loader"],
       },
       {
-        test: /\.m?js$/, 
+        test: /\.m?js$/,
         exclude: /node_modules/,
         use: {
-            loader: 'babel-loader',
-            options: {
-              presets: ['@babel/preset-env']
-            }
-        }
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"],
+          },
+        },
       },
       {
         test: /\.scss$/,
         use: [
           { loader: MiniCssExtractPlugin.loader },
-          { loader: 'css-loader'},
-          { loader: 'postcss-loader'},
+          { loader: "css-loader" },
+          { loader: "postcss-loader" },
           {
-            loader: 'sass-loader',
-            options: {implementation: require('node-sass')}
-          }
-        ]
-      }
-    ]
-  }
+            loader: "sass-loader",
+            options: { implementation: require("node-sass") },
+          },
+        ],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Minor fixes to the build. Do not unncessarily pull in all of d3 for one function. Note that this optimization doesn't really do much since c3 already pulls in all of d3.

Fix minor error with CNAME still referenced in the webpack config.