### PR TITLE
Popup usability

### DIFF
--- a/src/components/OutbreakMap/DrawMapPrefectures.js
+++ b/src/components/OutbreakMap/DrawMapPrefectures.js
@@ -107,6 +107,8 @@ const drawMapPrefectures = (pageDraws, ddb, map) => {
   const popup = new mapboxgl.Popup({
     closeButton: false,
     closeOnClick: false,
+    offset: 25,
+    className: "popup-content",
   });
 
   map.on("mousemove", function (e) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -377,3 +377,7 @@ img.emoji {
   }
 
 }
+
+.popup-content:hover {
+  visibility: hidden;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -365,6 +365,11 @@ img.emoji {
 
 .map-popup {
   font-size: 12px;
+  margin-bottom: -5px;
+
+  h3 {
+    margin: 0;
+  }
 
   span.popup-increment {
     color: rgb(244,67,54);


### PR DESCRIPTION
@reustle 

Made the popups a little more compact, and prevented mouse getting inside a popup and causing it to "stick" and feel clunky.

Before:
![before](https://user-images.githubusercontent.com/5779535/80566017-ea297100-8a2c-11ea-9da4-6787a1fbe194.gif)

After:
![after](https://user-images.githubusercontent.com/5779535/80566045-ff060480-8a2c-11ea-80f6-f3b55529e2b3.gif)

