### PR TITLE
Remove lodash dependency

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,6 @@ module.exports = function (api) {
   api.cache(false);
   return {
     plugins: [
-      "lodash", // transforms/strips unused lodash deps.
       "date-fns",
     ],
     presets: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,19 +1656,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -8549,12 +8536,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "require-package-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "i18next": "^19.3.4",
     "i18next-browser-languagedetector": "^4.0.2",
     "loc-i18next": "^0.1.4",
-    "lodash": "^4.17.15",
     "tippy.js": "^6.1.0",
     "twemoji": "^12.1.5",
     "whatwg-fetch": "^3.0.0"
@@ -35,7 +34,6 @@
     "@babel/preset-env": "^7.9.0",
     "babel-loader": "^8.0.5",
     "babel-plugin-date-fns": "^2.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.1",

--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -1,10 +1,5 @@
 import * as c3 from "c3";
 import * as d3 from "d3";
-import map from "lodash/map";
-import reduce from "lodash/reduce";
-import filter from "lodash/filter";
-import mapValues from "lodash/mapValues";
-import values from "lodash/values";
 import i18next from "i18next";
 
 // Inject IE11 polyfill (not used in index.js).
@@ -16,48 +11,43 @@ const drawPrefectureTrajectoryChart = (
   lang
 ) => {
   const minimumConfirmed = 100;
-  const filteredPrefectures = filter(prefectures, (prefecture) => {
+  const filteredPrefectures = prefectures.filter((prefecture) => {
     return (
       prefecture.confirmed >= minimumConfirmed && !prefecture.pseudoPrefecture
     );
   });
-  const trajectories = reduce(
-    filteredPrefectures,
-    (t, prefecture) => {
-      const cumulativeConfirmed = reduce(
-        prefecture.dailyConfirmedCount,
-        (result, value) => {
-          if (result.length > 0) {
-            const sum = result[result.length - 1] + value;
-            result.push(sum);
-            return result;
-          } else {
-            return [value];
-          }
-        },
-        []
-      );
-      const cumulativeConfirmedFromMinimum = filter(
-        cumulativeConfirmed,
-        (value) => value >= minimumConfirmed
-      );
-      t[prefecture.name] = {
-        name: prefecture.name,
-        name_ja: prefecture.name_ja,
-        confirmed: prefecture.confirmed,
-        cumulativeConfirmed: cumulativeConfirmedFromMinimum,
-        lastIndex: cumulativeConfirmedFromMinimum.length - 1,
-      };
-      return t;
-    },
-    {}
-  );
+  const trajectories = filteredPrefectures.reduce((t, prefecture) => {
+    const cumulativeConfirmed = prefecture.dailyConfirmedCount.reduce(
+      (result, value) => {
+        if (result.length > 0) {
+          const sum = result[result.length - 1] + value;
+          result.push(sum);
+          return result;
+        } else {
+          return [value];
+        }
+      },
+      []
+    );
+    const cumulativeConfirmedFromMinimum = cumulativeConfirmed.filter(
+      (value) => value >= minimumConfirmed
+    );
+    t[prefecture.name] = {
+      name: prefecture.name,
+      name_ja: prefecture.name_ja,
+      confirmed: prefecture.confirmed,
+      cumulativeConfirmed: cumulativeConfirmedFromMinimum,
+      lastIndex: cumulativeConfirmedFromMinimum.length - 1,
+    };
+    return t;
+  }, {});
 
-  const columns = map(Object.values(trajectories), (prefecture) =>
+  const trajectoryValues = Object.values(trajectories);
+  const columns = trajectoryValues.map((prefecture) =>
     [prefecture.name].concat(prefecture.cumulativeConfirmed)
   );
 
-  const regions = mapValues(trajectories, (prefecture) => {
+  const regions = trajectoryValues.map((prefecture) => {
     const value = prefecture.lastIndex;
     if (value > 0) {
       return [{ start: value - 1, end: value, style: "dashed" }];
@@ -66,24 +56,19 @@ const drawPrefectureTrajectoryChart = (
     }
   });
 
-  const maxDays = reduce(
-    values(trajectories),
+  const maxDays = trajectoryValues.reduce(
     (a, b) => Math.max(a, b.lastIndex),
     0
   );
 
-  const nameMap = reduce(
-    trajectories,
-    (result, value) => {
-      if (lang === "en") {
-        result[value.name] = value.name;
-      } else {
-        result[value.name] = value.name_ja;
-      }
-      return result;
-    },
-    {}
-  );
+  const nameMap = trajectoryValues.reduce((result, prefecture) => {
+    if (lang === "en") {
+      result[prefecture.name] = prefecture.name;
+    } else {
+      result[prefecture.name] = prefecture.name_ja;
+    }
+    return result;
+  }, {});
 
   if (prefectureTrajectoryChart) {
     prefectureTrajectoryChart.destroy();

--- a/src/components/TravelRestrictions/TravelRestrictions.js
+++ b/src/components/TravelRestrictions/TravelRestrictions.js
@@ -1,5 +1,4 @@
 import i18next from "i18next";
-import orderBy from "lodash/orderBy";
 import twemoji from "twemoji";
 
 /**
@@ -17,9 +16,12 @@ const parseEmoji = (emoji) => {
 const travelRestrictionsHelper = (elementId, countries) => {
   const countryList = [];
   // Iterate through and render country links
-  orderBy(countries, "name", "desc").map((country) => {
+  countries.sort((a, b) => {
+    a["name"] < b["name"] ? 1 : b["name"] > a["name"] ? -1 : 0;
+  });
+  countries.map((country) => {
     const name = i18next.t(`countries.${country.name}`);
-    countryList.unshift(
+    countryList.push(
       `<a href="${country.link}" class="country-link">${parseEmoji(
         country.emoji
       )}${name}</a>`


### PR DESCRIPTION
Reference: #270 

Eliminates lodash from the app. Note that lodash is still used by babel, so it remains as a development dependency.

Production build goes from 793KiB to 769KiB, so its not a huge win.

## Before

```
✦3 ❯ npm run build-prod

> covid2019-japan@1.0.0 build-prod /Users/leonard-chin/src/github.com/reustle/covid19japan
> npx webpack --config webpack.prod.js

You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.
Hash: 08aea589163b19a5df79
Version: webpack 4.42.0
Time: 23018ms
Built at: 04/29/2020 5:28:53 PM
                                  Asset       Size  Chunks                          Chunk Names
                             embed.html   12.3 KiB          [emitted]               
                              index.css   8.01 KiB       0  [emitted]               index
                          index.css.map   10.7 KiB       0  [emitted] [dev]         index
                             index.html   12.3 KiB          [emitted]               
                               index.js    793 KiB       0  [emitted]        [big]  index
                   index.js.LICENSE.txt  170 bytes          [emitted]               
                           index.js.map   3.05 MiB       0  [emitted] [dev]         index
            static/avatars/alastair.jpg  929 bytes          [emitted]               
                 static/avatars/kay.jpg   1.28 KiB          [emitted]               
             static/avatars/leonard.jpg      3 KiB          [emitted]               
                static/avatars/mark.jpg   2.31 KiB          [emitted]               
               static/avatars/shane.jpg   2.04 KiB          [emitted]               
                     static/favicon.ico     15 KiB          [emitted]               
                     static/favicon.png   11.7 KiB          [emitted]               
static/icons/android-chrome-192x192.png   3.47 KiB          [emitted]               
static/icons/android-chrome-512x512.png   27.1 KiB          [emitted]               
      static/icons/apple-touch-icon.png   1.61 KiB          [emitted]               
         static/icons/browserconfig.xml  272 bytes          [emitted]               
         static/icons/favicon-16x16.png  468 bytes          [emitted]               
         static/icons/favicon-32x32.png  675 bytes          [emitted]               
        static/icons/mstile-150x150.png   1.24 KiB          [emitted]               
     static/icons/safari-pinned-tab.svg   8.61 KiB          [emitted]               
          static/icons/site.webmanifest  506 bytes          [emitted]               
                         static/map.jpg   48.8 KiB          [emitted]               
             static/prefectures.geojson    687 KiB          [emitted]        [big]  
Entrypoint index [big] = index.css index.js index.css.map index.js.map

```

## After


```
> npx webpack --config webpack.prod.js

You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.
Hash: 361ecbd0e3ef94b9f7ef
Version: webpack 4.42.0
Time: 9495ms
Built at: 04/29/2020 5:26:24 PM
                                  Asset       Size  Chunks                          Chunk Names
                             embed.html   12.3 KiB          [emitted]               
                              index.css   8.01 KiB       0  [emitted]               index
                          index.css.map   10.7 KiB       0  [emitted] [dev]         index
                             index.html   12.3 KiB          [emitted]               
                               index.js    769 KiB       0  [emitted]        [big]  index
                   index.js.LICENSE.txt  170 bytes          [emitted]               
                           index.js.map    2.9 MiB       0  [emitted] [dev]         index
            static/avatars/alastair.jpg  929 bytes          [emitted]               
                 static/avatars/kay.jpg   1.28 KiB          [emitted]               
             static/avatars/leonard.jpg      3 KiB          [emitted]               
                static/avatars/mark.jpg   2.31 KiB          [emitted]               
               static/avatars/shane.jpg   2.04 KiB          [emitted]               
                     static/favicon.ico     15 KiB          [emitted]               
                     static/favicon.png   11.7 KiB          [emitted]               
static/icons/android-chrome-192x192.png   3.47 KiB          [emitted]               
static/icons/android-chrome-512x512.png   27.1 KiB          [emitted]               
      static/icons/apple-touch-icon.png   1.61 KiB          [emitted]               
         static/icons/browserconfig.xml  272 bytes          [emitted]               
         static/icons/favicon-16x16.png  468 bytes          [emitted]               
         static/icons/favicon-32x32.png  675 bytes          [emitted]               
        static/icons/mstile-150x150.png   1.24 KiB          [emitted]               
     static/icons/safari-pinned-tab.svg   8.61 KiB          [emitted]               
          static/icons/site.webmanifest  506 bytes          [emitted]               
                         static/map.jpg   48.8 KiB          [emitted]               
             static/prefectures.geojson    687 KiB          [emitted]        [big]  
Entrypoint index [big] = index.css index.js index.css.map index.js.map
```

