### PR TITLE
Remove date-fns babel plugin optimization

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = function (api) {
   api.cache(false);
   return {
-    plugins: ["date-fns"],
     presets: [
       [
         "@babel/preset-env",


### PR DESCRIPTION
Fixes missing date labels on daily increase chart. Seems like something in date-fns babel plugin is stripping too much.