### PR TITLE
Separate Mapbox API key from the source in order to override.

### DIFF
--- a/src/components/OutbreakMap/ApiKey.js
+++ b/src/components/OutbreakMap/ApiKey.js
@@ -1,0 +1,2 @@
+export const MAPBOX_API_KEY =
+  "pk.eyJ1IjoicmV1c3RsZSIsImEiOiJjazZtaHE4ZnkwMG9iM3BxYnFmaDgxbzQ0In0.nOiHGcSCRNa9MD9WxLIm7g";

--- a/src/components/OutbreakMap/DrawMap.js
+++ b/src/components/OutbreakMap/DrawMap.js
@@ -1,5 +1,5 @@
-const MAPBOX_API_KEY =
-  "pk.eyJ1IjoicmV1c3RsZSIsImEiOiJjazZtaHE4ZnkwMG9iM3BxYnFmaDgxbzQ0In0.nOiHGcSCRNa9MD9WxLIm7g";
+import { MAPBOX_API_KEY } from "./ApiKey";
+
 const MAP_CONFIG = {
   container: "map-container",
   style: "mapbox://styles/mapbox/light-v10?optimize=true",


### PR DESCRIPTION
Separate our the Mapbox API key so that it can be locally overridden during dev.

The current key forbids loading from localhost which means it is really hard to catch regressions on the map when developing.