### PR TITLE
Protect against totalRows not available.

### DIFF
--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -11,11 +11,8 @@ const prefectureTrendChartURL = (prefectureName) => {
 };
 
 const drawPrefectureTable = (prefectures, totals) => {
-  console.log("Running drawPrefectureTable");
-
   // Draw the Cases By Prefecture table
   const dataTable = document.querySelector("#prefectures-table");
-  console.log(dataTable);
   // Abort if dataTable is not accessible.
   if (!dataTable) {
     return;

--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -11,9 +11,11 @@ const prefectureTrendChartURL = (prefectureName) => {
 };
 
 const drawPrefectureTable = (prefectures, totals) => {
+  console.log("Running drawPrefectureTable");
+
   // Draw the Cases By Prefecture table
   const dataTable = document.querySelector("#prefectures-table");
-
+  console.log(dataTable);
   // Abort if dataTable is not accessible.
   if (!dataTable) {
     return;
@@ -135,10 +137,12 @@ const drawPrefectureTable = (prefectures, totals) => {
     dataTable.replaceChild(cruiseRows, existingCruiseRows);
   }
 
-  totalRows.querySelector(".prefecture").innerHTML = i18next.t("total");
-  totalRows.querySelector(".confirmed").innerHTML = totals.confirmed;
-  totalRows.querySelector(".recovered").innerHTML = totals.recovered;
-  totalRows.querySelector(".deceased").innerHTML = totals.deceased;
+  if (totalRows) {
+    totalRows.querySelector(".prefecture").innerHTML = i18next.t("total");
+    totalRows.querySelector(".confirmed").innerHTML = totals.confirmed;
+    totalRows.querySelector(".recovered").innerHTML = totals.recovered;
+    totalRows.querySelector(".deceased").innerHTML = totals.deceased;
+  }
 };
 
 export default drawPrefectureTable;


### PR DESCRIPTION
This should not happen, but seems like in the wild, the HTML can be old but the JS is new, and that will cause the JS not getting the right elements when using querySelector.

I have no idea why this could be, but it's happening in the wild.
