### PR TITLE
Move date-fns locales to i18n exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ To add a new language
 1. Make a copy of an existing localization file (recommended: `src/i18n/en.json`), name it to match the new language (e.g. `ja.json`)
 2. Replace the translations in the file you just created
 3. Add the new language to the array of `LANGUAGES` and a fitting flag emoji to the array of `FLAGS` at the same index in `src/i18n/index.js`
+4. Add the appropriate `date-fns` locale to the imports of `src/i18n/index.js`, and append that locale to the LOCALES export.
 
 ## License & Code Re-use
 

--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -1,7 +1,8 @@
 import * as c3 from "c3";
 import i18next from "i18next";
 import format from "date-fns/format";
-import { enUS, ja } from "date-fns/locale";
+
+import { LOCALES } from "../../i18n";
 
 import {
   COLOR_TESTED,
@@ -11,10 +12,7 @@ import {
 } from "../../data/constants";
 
 const drawDailyIncreaseChart = (trends, dailyIncreaseChart, lang) => {
-  let dateLocale = enUS;
-  if (lang == "ja") {
-    dateLocale = ja;
-  }
+  const dateLocale = LOCALES[lang];
 
   const cols = {
     Date: ["Date"],

--- a/src/components/Header/DrawLastUpdated.js
+++ b/src/components/Header/DrawLastUpdated.js
@@ -1,13 +1,13 @@
 import i18next from "i18next";
 import { formatDistanceToNow, parse, parseISO } from "date-fns";
-import { enUS, ja, es } from "date-fns/locale";
 
+import { LANGUAGES, LOCALES } from "../../i18n";
 import { TIME_FORMAT } from "../../data/constants";
 
 /**
  * @param {string} lastUpdatedString - MMM DD YYYY, HH:mm JST (e.g. Mar 29 2020, 15:53 JST)
  */
-const drawLastUpdated = (lastUpdatedString, lang) => {
+const drawLastUpdated = (lastUpdatedString, currentLanguage) => {
   // Draw the last updated time
   // If this is called before data is loaded, lastUpdated can be null.
   if (!lastUpdatedString) {
@@ -36,36 +36,36 @@ const drawLastUpdated = (lastUpdatedString, lang) => {
     display.textContent = lastUpdatedString;
     return;
   }
-  const relativeTime = {
-    en: formatDistanceToNow(lastUpdated, {
-      locale: enUS,
-      addSuffix: true,
-    }),
-    ja: formatDistanceToNow(lastUpdated, { locale: ja, addSuffix: true }),
-    es: formatDistanceToNow(lastUpdated, { locale: es, addSuffix: true }),
-  };
 
-  display.textContent = relativeTime[lang];
+  for (const language of LANGUAGES) {
+    addRelativeTimeLocalization(lastUpdated, language);
+  }
+
   display.setAttribute("title", lastUpdatedString);
-  i18next.addResource(
-    "en",
-    "translation",
-    "last-updated-time",
-    relativeTime["en"]
-  );
-  i18next.addResource(
-    "ja",
-    "translation",
-    "last-updated-time",
-    relativeTime["ja"]
-  );
-  i18next.addResource(
-    "es",
-    "translation",
-    "last-updated-time",
-    relativeTime["es"]
-  );
   display.setAttribute("data-i18n", "last-updated-time");
+  display.textContent = i18next.getResource(
+    currentLanguage,
+    "translation",
+    "last-updated-time"
+  );
 };
+
+function addRelativeTimeLocalization(lastUpdated, language) {
+  const relativeTime = getLocalizedRelativeTime(lastUpdated, language);
+  i18next.addResource(
+    language,
+    "translation",
+    "last-updated-time",
+    relativeTime
+  );
+}
+
+function getLocalizedRelativeTime(lastUpdated, language) {
+  const locale = LOCALES[language];
+  return formatDistanceToNow(lastUpdated, {
+    locale,
+    addSuffix: true,
+  });
+}
 
 export default drawLastUpdated;

--- a/src/components/Header/DrawLastUpdated.js
+++ b/src/components/Header/DrawLastUpdated.js
@@ -4,6 +4,24 @@ import { formatDistanceToNow, parse, parseISO } from "date-fns";
 import { LANGUAGES, LOCALES } from "../../i18n";
 import { TIME_FORMAT } from "../../data/constants";
 
+const addRelativeTimeLocalization = (lastUpdated, language) => {
+  const relativeTime = getLocalizedRelativeTime(lastUpdated, language);
+  i18next.addResource(
+    language,
+    "translation",
+    "last-updated-time",
+    relativeTime
+  );
+};
+
+const getLocalizedRelativeTime = (lastUpdated, language) => {
+  const locale = LOCALES[language];
+  return formatDistanceToNow(lastUpdated, {
+    locale,
+    addSuffix: true,
+  });
+};
+
 /**
  * @param {string} lastUpdatedString - MMM DD YYYY, HH:mm JST (e.g. Mar 29 2020, 15:53 JST)
  */
@@ -49,23 +67,5 @@ const drawLastUpdated = (lastUpdatedString, currentLanguage) => {
     "last-updated-time"
   );
 };
-
-function addRelativeTimeLocalization(lastUpdated, language) {
-  const relativeTime = getLocalizedRelativeTime(lastUpdated, language);
-  i18next.addResource(
-    language,
-    "translation",
-    "last-updated-time",
-    relativeTime
-  );
-}
-
-function getLocalizedRelativeTime(lastUpdated, language) {
-  const locale = LOCALES[language];
-  return formatDistanceToNow(lastUpdated, {
-    locale,
-    addSuffix: true,
-  });
-}
 
 export default drawLastUpdated;

--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -2,7 +2,8 @@ import * as c3 from "c3";
 import { color as d3_color } from "d3-color";
 import i18next from "i18next";
 import { format as dateFormat } from "date-fns";
-import { enUS, ja } from "date-fns/locale";
+
+import { LOCALES } from "../../i18n";
 
 import {
   COLOR_ACTIVE,
@@ -13,10 +14,7 @@ import {
 } from "../../data/constants";
 
 const drawTrendChart = (sheetTrend, trendChart, lang) => {
-  let dateLocale = enUS;
-  if (lang == "ja") {
-    dateLocale = ja;
-  }
+  const dateLocale = LOCALES[lang];
 
   const cols = {
     Date: ["Date"],

--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -62,11 +62,12 @@ const drawPrefectureTrajectoryChart = (
   );
 
   const nameMap = trajectoryValues.reduce((result, prefecture) => {
-    if (lang === "en") {
-      result[prefecture.name] = prefecture.name;
-    } else {
-      result[prefecture.name] = prefecture.name_ja;
-    }
+    result[prefecture.name] =
+      i18next.getResource(
+        lang,
+        "translation",
+        `prefectures.${prefecture.name}`
+      ) || prefecture.name;
     return result;
   }, {});
 

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,6 +1,10 @@
+import { enUS, ja, es } from "date-fns/locale";
+
 // Add new languages and their emoji flag here. Make sure the array indices line up.
 export const LANGUAGES = ["en", "ja", "es"];
 export const FLAGS = ["🇺🇸", "🇯🇵", "🇪🇸"];
+// Add locales for date-fns here. Make sure the keys match the languages in LANGUAGES.
+export const LOCALES = { en: enUS, ja: ja, es: es };
 
 const generateExport = () => {
   const resources = {};


### PR DESCRIPTION
@liquidx @mertd 
Closes #289 

This is what I came up with for simplifying the process of adding new translations. Unfortunately I had to add a LOCALES export to the `src/i18n/index.js` file, meaning there's another small step for translation contributors to handle, but all the other related things were able to be automated outside that file.