### PR TITLE
Fix prefecture trajectory chart to use translated prefecture names

### DIFF
--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -32,9 +32,14 @@ const drawPrefectureTrajectoryChart = (
     const cumulativeConfirmedFromMinimum = cumulativeConfirmed.filter(
       (value) => value >= minimumConfirmed
     );
-    t[prefecture.name] = {
-      name: prefecture.name,
-      name_ja: prefecture.name_ja,
+    const translatedName =
+      i18next.getResource(
+        lang,
+        "translation",
+        `prefectures.${prefecture.name}`
+      ) || prefecture.name;
+    t[translatedName] = {
+      name: translatedName,
       confirmed: prefecture.confirmed,
       cumulativeConfirmed: cumulativeConfirmedFromMinimum,
       lastIndex: cumulativeConfirmedFromMinimum.length - 1,
@@ -60,16 +65,6 @@ const drawPrefectureTrajectoryChart = (
     (a, b) => Math.max(a, b.lastIndex),
     0
   );
-
-  const nameMap = trajectoryValues.reduce((result, prefecture) => {
-    result[prefecture.name] =
-      i18next.getResource(
-        lang,
-        "translation",
-        `prefectures.${prefecture.name}`
-      ) || prefecture.name;
-    return result;
-  }, {});
 
   if (prefectureTrajectoryChart) {
     prefectureTrajectoryChart.destroy();
@@ -110,7 +105,6 @@ const drawPrefectureTrajectoryChart = (
           }
         },
       },
-      names: nameMap,
       color: (originalColor, d) => {
         let color = d3.hsl(originalColor);
         if (!d || !d.id) {


### PR DESCRIPTION
Hi @reustle 

This fixes #335 by using the translated the prefecture name internally, too, when collecting per-prefecture trajectory data. There does not appear to be any use for the original, English name of each prefecture in the chart, as any translated name can be used as the index just as well.

Before:
<img width="840" alt="before" src="https://user-images.githubusercontent.com/2044745/82006008-cc514280-96a1-11ea-8aeb-1d6f73ffedf0.png">

After:
<img width="839" alt="after" src="https://user-images.githubusercontent.com/2044745/82006020-d3785080-96a1-11ea-9488-0d571a0fdf62.png">


