### PR TITLE
Replace language code and flag with proper language name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ All strings in the `src/` files should be localized like this:
 
 To add a new language
 
-1. Make a copy of an existing localization file (recommended: `src/i18n/en.json`), name it to match the new language (e.g. `ja.json`)
-2. Replace the translations in the file you just created
-3. Add the new language to the array of `LANGUAGES` and a fitting flag emoji to the array of `FLAGS` at the same index in `src/i18n/index.js`
+1. Make a copy of an existing localization file (recommended: `src/i18n/en.json`), name it to match the new language (e.g. `ja.json`).
+2. Replace the translations in the file you just created.
+3. Add the new language to the array of `LANGUAGES` and `LANGUAGE_NAMES` of `src/i18n/index.js`.
 4. Add the appropriate `date-fns` locale to the imports of `src/i18n/index.js`, and append that locale to the LOCALES export.
 
 ## License & Code Re-use

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "covid-19-tracker": "Japan COVID-19 Coronavirus Tracker",
+  "languages": "Languages:",
   "last-updated": "Last Updated:",
   "kpi-active": "Active",
   "kpi-active-tooltip": "Confirmed cases minus recovered minus deceased",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,8 +1,18 @@
 import { enUS, ja, es, de, ptBR, fr, id, pl, fi } from "date-fns/locale";
 
 // Add new languages and their emoji flag here. Make sure the array indices line up.
-export const LANGUAGES = ["en", "ja", "es", "de", "pt", "fr", "id", "pl", "fi"];
-export const FLAGS = ["🇺🇸", "🇯🇵", "🇪🇸", "🇩🇪", "🇧🇷", "🇫🇷", "🇮🇩", "🇵🇱", "🇫🇮"];
+export const LANGUAGES = ["en", "ja", "id", "es", "fr", "de", "pl", "pt", "fi"];
+export const LANGUAGE_NAMES = [
+  "English",
+  "日本語",
+  "Bahasa Indonesia",
+  "Español",
+  "Français",
+  "Deutsch",
+  "Polski",
+  "Português",
+  "Suomi",
+];
 // Add locales for date-fns here. Make sure the keys match the languages in LANGUAGES.
 export const LOCALES = {
   en: enUS,

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,5 +1,6 @@
 {
   "covid-19-tracker": "日本国内の新型コロナウイルス (COVID-19) 感染状況追跡",
+  "languages": "言語:",
   "last-updated": "最終更新:",
   "kpi-active": "既存感染者数",
   "kpi-active-tooltip": "感染者数から回復者数と死亡者数を引いた数",

--- a/src/index.html
+++ b/src/index.html
@@ -58,13 +58,9 @@
       <h1 data-i18n="covid-19-tracker">Japan COVID-19 Coronavirus Tracker</h1>
       <div class="toolbar">
         <div class="lang-picker">
-          <!-- will be populated from supported language list -->
-          <a href="#" data-lang-picker='en'>EN 🇺🇸</a> |
-          <a href="#" data-lang-picker='ja'>JA 🇯🇵</a> |
-          <a href="#" data-lang-picker='es'>ES 🇪🇸</a> |
-          <a href="#" data-lang-picker='de'>DE 🇩🇪</a> |
-          <a href="#" data-lang-picker='es'>PT 🇧🇷</a> |
-          <a href="#" data-lang-picker='es'>ID 🇮🇩</a>                  
+          <span class="lang-picker-title" data-i18n="languages">Languages:</span>
+          <span class="lang-picker-languages">
+          </span>
         </div>
         <div id="last-updated">
           <span data-i18n="last-updated">Last Updated:</span> <strong id="last-updated-time">-</strong>

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ import "custom-event-polyfill";
 import i18next from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import locI18next from "loc-i18next";
-import twemoji from "twemoji";
 
 import { calculateTotals } from "./data/helper";
 import header from "./components/Header";
@@ -49,7 +48,7 @@ import {
   DDB_COMMON,
 } from "./data/constants";
 import travelRestrictions from "./data/travelRestrictions"; // refer to the keys under "countries" in the i18n files for names
-import { FLAGS, LANGUAGES } from "./i18n";
+import { LANGUAGES, LANGUAGE_NAMES } from "./i18n";
 
 //
 // Globals
@@ -180,15 +179,14 @@ const setLang = (lng) => {
 };
 
 const populateLanguageSelector = () => {
-  const parent = document.getElementsByClassName("lang-picker")[0];
+  const parent = document.getElementsByClassName("lang-picker-languages")[0];
   parent.innerHTML = "";
   for (let i in LANGUAGES) {
     parent.innerHTML =
       parent.innerHTML +
-      `<a href="#" data-lang-picker='${LANGUAGES[i].toLowerCase()}'>${LANGUAGES[
-        i
-      ].toUpperCase()} ${twemoji.parse(FLAGS[i])}</a> `;
-    if (i <= LANGUAGES.length - 2) parent.innerHTML = parent.innerHTML + `| `;
+      `<a href="#" class="lang-picker-button" data-lang-picker='${LANGUAGES[i]}'>${LANGUAGE_NAMES[i]}</a> `;
+    if (i <= LANGUAGES.length - 2)
+      parent.innerHTML = parent.innerHTML + `&nbsp;| `;
   }
 };
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -74,15 +74,24 @@ header {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    font-size: 0.8em;
+    font-size: 0.8rem;
+
+    .lang-picker-title {
+      font-style: italic;
+      margin-right: 0.5rem;
+    }
+
+    .lang-picker-button {
+      word-wrap: none;
+    }
     
     .lang-picker {
       padding: 0.5rem 1em 0.5em 0;
       a {
         white-space: nowrap;
         text-decoration: none;
+        margin-bottom: 0.3rem;
         &.active {
-          padding-bottom: 4px;
           border-bottom: solid 2px black;
           font-weight: $font-weight-bold;
         }


### PR DESCRIPTION
While this is longer, it is more usable and accessible as non-techies aren't really familiar with the language codes.

Also, the flags do not map to the languages (e.g. brazil or portugal flag for Portuguese?? UK or US or Australian flag for English?)
![localhost_4000_ (16)](https://user-images.githubusercontent.com/72062/82113612-609ad280-9792-11ea-9686-f0dae07188b4.png)
