### PR TITLE
Make the time period for the DailyIncrease and SpreadTrend dynamic

### DIFF
--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -7,11 +7,16 @@ import { LOCALES } from "../../i18n";
 import {
   COLOR_TESTED,
   COLOR_TESTED_DAILY,
-  CHART_TIME_PERIOD,
+  DEFAULT_CHART_TIME_PERIOD,
   COLOR_CONFIRMED,
 } from "../../data/constants";
 
-const drawDailyIncreaseChart = (trends, dailyIncreaseChart, lang) => {
+const drawDailyIncreaseChart = (
+  trends,
+  dailyIncreaseChart,
+  lang,
+  timePeriod = DEFAULT_CHART_TIME_PERIOD
+) => {
   const dateLocale = LOCALES[lang];
 
   const cols = {
@@ -20,7 +25,9 @@ const drawDailyIncreaseChart = (trends, dailyIncreaseChart, lang) => {
     ConfirmedAvg: ["ConfirmedAvg"],
   };
 
-  for (let i = trends.length - CHART_TIME_PERIOD; i < trends.length; i++) {
+  const startIndex = timePeriod > 0 ? trends.length - timePeriod : 0;
+  console.log(startIndex, timePeriod);
+  for (let i = startIndex; i < trends.length; i++) {
     const row = trends[i];
 
     cols.Date.push(row.date);

--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -10,10 +10,15 @@ import {
   COLOR_CONFIRMED,
   COLOR_RECOVERED,
   COLOR_DECEASED,
-  CHART_TIME_PERIOD,
+  DEFAULT_CHART_TIME_PERIOD,
 } from "../../data/constants";
 
-const drawTrendChart = (sheetTrend, trendChart, lang) => {
+const drawTrendChart = (
+  sheetTrend,
+  trendChart,
+  lang,
+  timePeriod = DEFAULT_CHART_TIME_PERIOD
+) => {
   const dateLocale = LOCALES[lang];
 
   const cols = {
@@ -26,11 +31,8 @@ const drawTrendChart = (sheetTrend, trendChart, lang) => {
     Tested: ["Tested"],
   };
 
-  for (
-    let i = sheetTrend.length - CHART_TIME_PERIOD;
-    i < sheetTrend.length;
-    i++
-  ) {
+  const startIndex = timePeriod > 0 ? sheetTrend.length - timePeriod : 0;
+  for (let i = startIndex; i < sheetTrend.length; i++) {
     const row = sheetTrend[i];
 
     cols.Date.push(row.date);

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,7 +1,7 @@
 import languageResources, { LANGUAGES } from "../i18n";
 
 export const TIME_FORMAT = "MMMM d yyyy, HH:mm";
-export const CHART_TIME_PERIOD = 60;
+export const DEFAULT_CHART_TIME_PERIOD = 60;
 export const COLOR_ACTIVE = "rgb(223,14,31)";
 export const COLOR_CONFIRMED = "rgb(244,67,54)";
 export const COLOR_RECOVERED = "rgb(25,118,210)";

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ import {
   JSON_PATH,
   SUPPORTED_LANGS,
   DDB_COMMON,
+  DEFAULT_CHART_TIME_PERIOD,
 } from "./data/constants";
 import travelRestrictions from "./data/travelRestrictions"; // refer to the keys under "countries" in the i18n files for names
 import { LANGUAGES, LANGUAGE_NAMES } from "./i18n";
@@ -55,6 +56,7 @@ import { LANGUAGES, LANGUAGE_NAMES } from "./i18n";
 //
 
 let LANG = "en";
+let CHART_TIME_PERIOD = DEFAULT_CHART_TIME_PERIOD;
 
 const PAGE_STATE = {
   map: null,
@@ -160,11 +162,17 @@ const setLang = (lng) => {
       }
       if (ddb.isLoaded()) {
         drawKpis(ddb.totals, ddb.totalsDiff);
-        trendChart = drawTrendChart(ddb.trend, trendChart, LANG);
+        trendChart = drawTrendChart(
+          ddb.trend,
+          trendChart,
+          LANG,
+          CHART_TIME_PERIOD
+        );
         dailyIncreaseChart = drawDailyIncreaseChart(
           ddb.trend,
           dailyIncreaseChart,
-          LANG
+          LANG,
+          CHART_TIME_PERIOD
         );
         prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
           ddb.prefectures,
@@ -318,13 +326,19 @@ document.addEventListener("covid19japan-redraw", () => {
     callIfUpdated(() => drawLastUpdated(ddb.lastUpdated, LANG));
     callIfUpdated(() => drawPageTitleCount(ddb.totals.confirmed));
     callIfUpdated(() => {
-      trendChart = drawTrendChart(ddb.trend, trendChart, LANG);
+      trendChart = drawTrendChart(
+        ddb.trend,
+        trendChart,
+        LANG,
+        CHART_TIME_PERIOD
+      );
     });
     callIfUpdated(() => {
       dailyIncreaseChart = drawDailyIncreaseChart(
         ddb.trend,
         dailyIncreaseChart,
-        LANG
+        LANG,
+        CHART_TIME_PERIOD
       );
     });
     callIfUpdated(() => {


### PR DESCRIPTION
Hi @reustle 

As a first step towards #365, I did some small changes in the backend to make the two charts' time period more dynamic, controlled by the variable `CHART_TIME_PERIOD` (defaulting to the old default renamed to `DEFAULT_CHART_TIME_PERIOD`).

Positive values of `CHART_TIME_PERIOD` behave like before, while negative or zero instead use the full time scale.

No attempt to creating a UI component to control its value (or trigger re-rendering the charts) was made, but just with this it's easier to hack the value with a debugger.

<img width="1180" alt="Screen Shot 2020-07-03 at 13 11 13" src="https://user-images.githubusercontent.com/2044745/86431057-b7eb0700-bd2e-11ea-95cd-2003b62691d0.png">
