### PR TITLE
Replace hardcoding of chart scales with a generated scale.

### DIFF
--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -3,6 +3,7 @@ import i18next from "i18next";
 import format from "date-fns/format";
 
 import { LOCALES } from "../../i18n";
+import { niceScale } from "../../data/scaling";
 
 import {
   COLOR_TESTED,
@@ -38,6 +39,11 @@ const drawDailyIncreaseChart = (
       cols.ConfirmedAvg.push(row.confirmedAvg7d);
     }
   }
+
+  const scale = niceScale(
+    cols.Confirmed.slice(1).concat(cols.ConfirmedAvg.slice(1)),
+    5
+  );
 
   if (dailyIncreaseChart) {
     dailyIncreaseChart.destroy();
@@ -101,8 +107,10 @@ const drawDailyIncreaseChart = (
         },
       },
       y: {
+        padding: 0,
+        max: scale.max,
         tick: {
-          values: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+          values: scale.ticks,
         },
       },
     },
@@ -125,6 +133,8 @@ const drawDailyIncreaseChart = (
     },
     padding: {
       right: 24,
+      top: 0,
+      bottom: 0,
     },
   });
   return dailyIncreaseChart;

--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -4,6 +4,7 @@ import i18next from "i18next";
 import { format as dateFormat } from "date-fns";
 
 import { LOCALES } from "../../i18n";
+import { niceScale } from "../../data/scaling";
 
 import {
   COLOR_ACTIVE,
@@ -45,6 +46,8 @@ const drawTrendChart = (
     );
     cols.Tested.push(row.testedCumulative);
   }
+
+  const scale = niceScale(cols.Confirmed.slice(1), 5);
 
   if (trendChart) {
     trendChart.destroy();
@@ -97,7 +100,7 @@ const drawTrendChart = (
       pattern: [COLOR_CONFIRMED, COLOR_ACTIVE, COLOR_RECOVERED, COLOR_DECEASED],
     },
     point: {
-      r: 2,
+      r: 1,
     },
     axis: {
       x: {
@@ -117,23 +120,10 @@ const drawTrendChart = (
         },
       },
       y: {
-        padding: {
-          bottom: 0,
-        },
+        padding: 0,
+        max: scale.max,
         tick: {
-          values: [
-            0,
-            2000,
-            4000,
-            6000,
-            8000,
-            10000,
-            12000,
-            14000,
-            16000,
-            18000,
-            20000,
-          ],
+          values: scale.ticks,
         },
       },
     },
@@ -161,6 +151,8 @@ const drawTrendChart = (
     },
     padding: {
       right: 24,
+      top: 0,
+      bottom: 0,
     },
   });
   return trendChart;

--- a/src/data/scaling.js
+++ b/src/data/scaling.js
@@ -1,0 +1,23 @@
+// Returns a nicely rounded scale based on the number of ticks.
+export const niceScale = (values, tickCount) => {
+  let max = Math.max(...values);
+  let ticks = [];
+
+  let tickIncrement = max / tickCount;
+  // Take the tickIncrement and find the nearest power of 10 smaller than tickIncrement.
+  // e.g. 45 -> 10, 455 -> 100
+  let magnitude10 = Math.pow(10, Math.ceil(Math.log10(tickIncrement)) - 1);
+  // Round up tickIncrement to the nearest power of 10.
+  // e.g. 45 -> 50, 455 -> 500
+  tickIncrement = Math.ceil(tickIncrement / magnitude10) * magnitude10;
+
+  max = tickIncrement * tickCount;
+  for (let i = 1; i <= tickCount; i++) {
+    ticks.push(i * tickIncrement);
+  }
+
+  return {
+    max: max,
+    ticks: ticks,
+  };
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -146,7 +146,7 @@ a, a:hover, a:visited {
 }
 
 #daily-increase-chart-box, #trend-chart-box {
-  padding: 10px 10px 5px 10px;
+  padding: 20px 10px 5px 10px;
   border-radius: $box-border-radius;
   background: $color-box-background;
   box-shadow: $color-box-shadow;


### PR DESCRIPTION
Before:

<img width="1244" alt="Screen Shot 2020-07-03 at 21 27 03" src="https://user-images.githubusercontent.com/72062/86469242-f656e500-bd73-11ea-92c5-7f8cba5da61e.png">


After:

<img width="1234" alt="Screen Shot 2020-07-03 at 21 26 49" src="https://user-images.githubusercontent.com/72062/86469253-f9ea6c00-bd73-11ea-99f4-3c1b9605d37c.png">
