### PR TITLE
Double the chart time period.

### DIFF
--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -27,7 +27,6 @@ const drawDailyIncreaseChart = (
   };
 
   const startIndex = timePeriod > 0 ? trends.length - timePeriod : 0;
-  console.log(startIndex, timePeriod);
   for (let i = startIndex; i < trends.length; i++) {
     const row = trends[i];
 
@@ -132,7 +131,8 @@ const drawDailyIncreaseChart = (
       },
     },
     padding: {
-      right: 24,
+      left: 40,
+      right: 10,
       top: 0,
       bottom: 0,
     },

--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -150,7 +150,8 @@ const drawTrendChart = (
       },
     },
     padding: {
-      right: 24,
+      left: 40,
+      right: 10,
       top: 0,
       bottom: 0,
     },

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,7 +1,7 @@
 import languageResources, { LANGUAGES } from "../i18n";
 
 export const TIME_FORMAT = "MMMM d yyyy, HH:mm";
-export const DEFAULT_CHART_TIME_PERIOD = 60;
+export const DEFAULT_CHART_TIME_PERIOD = 120;
 export const COLOR_ACTIVE = "rgb(223,14,31)";
 export const COLOR_CONFIRMED = "rgb(244,67,54)";
 export const COLOR_RECOVERED = "rgb(25,118,210)";


### PR DESCRIPTION
This allows us to see the first wave and the current numbers in context.

<img width="977" alt="Screen Shot 2020-07-04 at 20 31 13" src="https://user-images.githubusercontent.com/72062/86511561-64afac00-be35-11ea-9a3e-89afe69adcf3.png">
