### PR TITLE
Add the today/yesterday increments on the total row of the prefecture table

### DIFF
--- a/src/components/PrefectureTable/PrefectureTable.js
+++ b/src/components/PrefectureTable/PrefectureTable.js
@@ -97,6 +97,9 @@ export const drawPrefectureTable = (prefectureTable, prefectures, totals) => {
     "pseudo-prefecture": pseudoPrefectureRows,
   };
 
+  let totalNewlyConfirmed = 0;
+  let totalYesterdayConfirmed = 0;
+
   prefectures.map((pref, i) => {
     let rowId = `row${i}`;
     let row = prefectureTable.querySelector(`.${rowId}`);
@@ -111,10 +114,12 @@ export const drawPrefectureTable = (prefectureTable, prefectures, totals) => {
     let todayConfirmedString = "";
     let yesterdayConfirmedString = "";
     if (pref.newlyConfirmed > 0) {
+      totalNewlyConfirmed += pref.newlyConfirmed;
       todayConfirmedString = `(&nbsp;+${pref.newlyConfirmed}&nbsp;)`;
     }
     if (pref.yesterdayConfirmed > 0) {
       yesterdayConfirmedString = `(&nbsp;+${pref.yesterdayConfirmed}&nbsp;)`;
+      totalYesterdayConfirmed += pref.yesterdayConfirmed;
     }
 
     if (isPseudoPrefecture && !existingPseudoPrefectureRows) {
@@ -165,6 +170,18 @@ export const drawPrefectureTable = (prefectureTable, prefectures, totals) => {
     existingTotalRows.querySelector(".confirmed").innerHTML = totals.confirmed;
     existingTotalRows.querySelector(".recovered").innerHTML = totals.recovered;
     existingTotalRows.querySelector(".deceased").innerHTML = totals.deceased;
+    let todayConfirmedString = "";
+    let yesterdayConfirmedString = "";
+    if (totalNewlyConfirmed > 0) {
+      todayConfirmedString = `(&nbsp;+${totalNewlyConfirmed}&nbsp;)`;
+    }
+    if (totalYesterdayConfirmed > 0) {
+      yesterdayConfirmedString = `(&nbsp;+${totalYesterdayConfirmed}&nbsp;)`;
+    }
+    existingTotalRows.querySelector(".today").innerHTML = todayConfirmedString;
+    existingTotalRows.querySelector(
+      ".yesterday"
+    ).innerHTML = yesterdayConfirmedString;
   }
 
   // Remove any loaders

--- a/src/index.html
+++ b/src/index.html
@@ -288,7 +288,7 @@
               <td class="prefecture" data-i18n="total">Total</td>
               <td class="trend"></td>
               <td class="confirmed"></td>
-              <td class="delta"></td>
+              <td class="delta"><div class="increment"><div class="today"></div><div class="yesterday"></div></div></td>
               <td class="recovered"></td>
               <td class="deceased"></td>
             </tr>


### PR DESCRIPTION
Hi @reustle

The lack of today's and yesterday's increment on the total row of the prefecture table felt like a sore spot, so I thought of adding them. While today's total increment is available in the KPI, you'd need to dig into "Daily Confirmed Cases" to get yesterday's increment.

<img width="862" alt="Screen Shot 2020-07-08 at 17 42 15" src="https://user-images.githubusercontent.com/2044745/86897500-74373980-c142-11ea-970b-bb5e247388f9.png">
