### PR TITLE
Fix prefecture secondary sorting within region

### DIFF
--- a/src/components/RegionalCharts/RegionalCharts.js
+++ b/src/components/RegionalCharts/RegionalCharts.js
@@ -304,9 +304,12 @@ export const drawRegionalCharts = (prefectureData, regionalData, lang) => {
           return 1;
         } else if (deltaB < deltaA) {
           return -1;
-        } else {
-          return a.active - b.active;
+        } else if (a.active < b.active) {
+          return 1;
+        } else if (b.active < a.active) {
+          return -1;
         }
+        return b.confirmed - a.confirmed;
       });
 
       //prefectures = prefectures.slice(0, MAX_PREFECTURES_IN_REGION);


### PR DESCRIPTION
Hi @reustle @liquidx 

I noticed that the sorting of the prefectures within regions seemed to be all over the place in some regions, but it was just that the secondary sorting by active cases was in ascending order. I reversed the order, and also added a third tiebreaker by total confirmed cases, which should make the list order reasonably deterministic...

Before:
<img width="1179" alt="Screen Shot 2020-07-18 at 23 46 09" src="https://user-images.githubusercontent.com/2044745/87855095-01ec0380-c951-11ea-8eb1-664e4b9143ce.png">

After:
<img width="1177" alt="Screen Shot 2020-07-18 at 23 50 30" src="https://user-images.githubusercontent.com/2044745/87855178-7de64b80-c951-11ea-9179-d9b4b93c3dc9.png">
