### PR TITLE
Fixed the design when the prefecture map is not displayed.

### DIFF
--- a/src/components/RegionalCharts/_regional.scss
+++ b/src/components/RegionalCharts/_regional.scss
@@ -75,7 +75,7 @@ $breakpoint-600-full-box-width: $breakpoint-600-page-width - $box-margin * 2;
 
 
 .region-top {
-  height: 10rem;
+  min-height: 10rem;
   width: 100%;
 
   .vitals {


### PR DESCRIPTION
Hi @reustle.

I found collapse when `prefecture-map-container` is not shown.
Occurs when the browser does not support `Mapbox GL JS`.
![before](https://user-images.githubusercontent.com/10064571/87859565-07594600-c971-11ea-8883-359a244f03c0.png)

I fixed it by changing the CSS height specification to min-height
![after](https://user-images.githubusercontent.com/10064571/87860335-936e6c00-c977-11ea-8845-d31ef375aa1b.png)
