### PR TITLE
Expand collapse prefecture v2

### DIFF
--- a/src/components/RegionalCharts/RegionalCharts.js
+++ b/src/components/RegionalCharts/RegionalCharts.js
@@ -8,6 +8,22 @@ const MAX_PREFECTURES_IN_REGION = 6;
 const MAX_REGIONS_IN_TOP_REGIONS = 4;
 const MAX_PREFECTURES_IN_TOP_REGIONS = 4;
 
+const hideSelectRegions = () => {
+  const allRegions = document.querySelectorAll(".region-box.region-area");
+
+  // Selects all regions after the top 3 to hide
+  const afterTopThreeRegions = Array.from(allRegions).slice(3);
+
+  afterTopThreeRegions.forEach((region) => {
+    const regionBoxPrefecture = region.querySelector(".region-box-prefectures");
+    const chevron = region.querySelector(".chevron");
+
+    region.classList.add("hide-region-container");
+    regionBoxPrefecture.classList.add("hide-region-box");
+    chevron.classList.add("rotate");
+  });
+};
+
 const drawRegionChart = (chartName, element) => {
   let svgURL = `https://data.covid19japan.com/charts/${chartName}`;
   fetch(svgURL)
@@ -143,6 +159,7 @@ export const createRegionBox = (regionName, region, numberFormatter) => {
   }
 
   const box = div(["region-box", "region-area"], { id: `region-${regionId}` }, [
+    div("chevron", {}, []),
     div("vitals", {}, [
       div(
         "title",
@@ -173,6 +190,16 @@ export const createRegionBox = (regionName, region, numberFormatter) => {
     ]),
     div("region-box-prefectures"),
   ]);
+
+  const chevron = box.querySelector(".chevron");
+  const regionBoxPrefecture = box.querySelector(".region-box-prefectures");
+
+  chevron.addEventListener("click", () => {
+    box.classList.toggle("hide-region-container");
+    regionBoxPrefecture.classList.toggle("hide-region-box");
+    chevron.classList.toggle("rotate");
+  });
+
   return box;
 };
 
@@ -379,6 +406,7 @@ export const drawRegionalCharts = (prefectureData, regionalData, lang) => {
   if (pseudoRegionPrefectureContainer.children.length > 0) {
     regionalContainer.appendChild(pseudoRegionBox);
   }
+  hideSelectRegions();
 };
 
 export const drawTopRegions = (prefectureData, regionalData, lang) => {

--- a/src/components/RegionalCharts/RegionalCharts.js
+++ b/src/components/RegionalCharts/RegionalCharts.js
@@ -8,20 +8,27 @@ const MAX_PREFECTURES_IN_REGION = 6;
 const MAX_REGIONS_IN_TOP_REGIONS = 4;
 const MAX_PREFECTURES_IN_TOP_REGIONS = 4;
 
+const PREFECTURES_VISIBLE_ON_LOAD = 3;
+
 const hideSelectRegions = () => {
   const allRegions = document.querySelectorAll(".region-box.region-area");
 
-  // Selects all regions after the top 3 to hide
-  const afterTopThreeRegions = Array.from(allRegions).slice(3);
+  if (MAX_PREFECTURES_IN_TOP_REGIONS <= allRegions.length) {
+    const afterTopThreeRegions = Array.from(allRegions).slice(
+      PREFECTURES_VISIBLE_ON_LOAD
+    );
 
-  afterTopThreeRegions.forEach((region) => {
-    const regionBoxPrefecture = region.querySelector(".region-box-prefectures");
-    const chevron = region.querySelector(".chevron");
+    afterTopThreeRegions.forEach((region) => {
+      const regionBoxPrefecture = region.querySelector(
+        ".region-box-prefectures"
+      );
+      const chevron = region.querySelector(".chevron");
 
-    region.classList.add("hide-region-container");
-    regionBoxPrefecture.classList.add("hide-region-box");
-    chevron.classList.add("rotate");
-  });
+      region.classList.add("hide-region-container");
+      regionBoxPrefecture.classList.add("hide-region-box");
+      chevron.classList.add("rotate");
+    });
+  }
 };
 
 const drawRegionChart = (chartName, element) => {

--- a/src/components/RegionalCharts/_regional.scss
+++ b/src/components/RegionalCharts/_regional.scss
@@ -41,10 +41,13 @@ $breakpoint-600-full-box-width: $breakpoint-600-page-width - $box-margin * 2;
 
 .region-area {
   height: 14rem;
+  max-height: 14rem;
+  transition: all 1s;
   width: $breakpoint-1200-full-box-width;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
+  position: relative;
 
   .vitals {
     width: 11rem;
@@ -58,6 +61,13 @@ $breakpoint-600-full-box-width: $breakpoint-600-page-width - $box-margin * 2;
     flex-wrap: nowrap;
     overflow-x: scroll;
     width: 100%;
+    max-height: 14rem;
+    transition: all 1s;
+  }
+  
+  .hide-region-box {
+    max-height: 0;
+    overflow:hidden;
   }
 }
 
@@ -381,4 +391,25 @@ a.region-top-link {
   // path.area {
   //   fill: url(#regional-chart-gradient) $primary-black !important;
   // }
+}
+
+.chevron {
+  width: 0; 
+  height: 0; 
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid #000;
+  position: absolute;
+  top: 0.8rem;
+  right: 0.8rem;
+}
+
+.rotate {
+  transform: rotate(180deg)
+}
+
+.hide-region-container {
+  max-height: 2.8rem;
+  transition: all 1s;
+  overflow:hidden;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -215,7 +215,7 @@ a, a:hover, a:visited {
 @import 'src/components/PrefectureTable/prefectureTable';
 
 #helpful-links,
-#travel-restrictions, {
+#travel-restrictions {
   max-width: 800px;
   margin: 0 auto;
   li {


### PR DESCRIPTION
// Please tag @reustle in your newly created PR
@reustle @liquidx 
// Please include a screenshot of any visual changes you've made
New branch and PR to add the same functionality to the newly visualized prefecture regions. I left the first three regions visible and hid the rest by default. This can be updated easily by a constant at the top of RegionalCharts.js.

![ezgif com-optimize (1)](https://user-images.githubusercontent.com/11080410/87863498-5e3b2d00-c929-11ea-9ed2-8740539f7e87.gif)


