### PR TITLE
Add Confirmed Case Trajectories by Region

### DIFF
--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -7,20 +7,20 @@ import { maybeIntlNumberFormat } from "../../i18n";
 // Inject IE11 polyfill (not used in index.js).
 import "core-js/es/object/values";
 
-const drawPrefectureTrajectoryChart = (
-  prefectures,
-  prefectureTrajectoryChart,
-  lang
+const drawTrajectoryChart = (
+  areas,
+  trajectoryChart,
+  lang,
+  bindElement,
+  type
 ) => {
   const formatNumber = maybeIntlNumberFormat(lang);
   const minimumConfirmed = 500;
-  const filteredPrefectures = prefectures.filter((prefecture) => {
-    return (
-      prefecture.confirmed >= minimumConfirmed && !prefecture.pseudoPrefecture
-    );
+  const filteredAreas = areas.filter((area) => {
+    return area.confirmed >= minimumConfirmed;
   });
-  const trajectories = filteredPrefectures.reduce((t, prefecture) => {
-    const cumulativeConfirmed = prefecture.dailyConfirmedCount.reduce(
+  const trajectories = filteredAreas.reduce((t, area) => {
+    const cumulativeConfirmed = area.dailyConfirmedCount.reduce(
       (result, value) => {
         if (result.length > 0) {
           const sum = result[result.length - 1] + value;
@@ -36,14 +36,11 @@ const drawPrefectureTrajectoryChart = (
       (value) => value >= minimumConfirmed
     );
     const translatedName =
-      i18next.getResource(
-        lang,
-        "translation",
-        `prefectures.${prefecture.name}`
-      ) || prefecture.name;
+      i18next.getResource(lang, "translation", `${type}.${area.name}`) ||
+      area.name;
     t[translatedName] = {
       name: translatedName,
-      confirmed: prefecture.confirmed,
+      confirmed: area.confirmed,
       cumulativeConfirmed: cumulativeConfirmedFromMinimum,
       lastIndex: cumulativeConfirmedFromMinimum.length - 1,
     };
@@ -51,12 +48,12 @@ const drawPrefectureTrajectoryChart = (
   }, {});
 
   const trajectoryValues = Object.values(trajectories);
-  const columns = trajectoryValues.map((prefecture) =>
-    [prefecture.name].concat(prefecture.cumulativeConfirmed)
+  const columns = trajectoryValues.map((area) =>
+    [area.name].concat(area.cumulativeConfirmed)
   );
 
-  const regions = trajectoryValues.map((prefecture) => {
-    const value = prefecture.lastIndex;
+  const regions = trajectoryValues.map((area) => {
+    const value = area.lastIndex;
     if (value > 0) {
       return [{ start: value - 1, end: value, style: "dashed" }];
     } else {
@@ -69,12 +66,12 @@ const drawPrefectureTrajectoryChart = (
     0
   );
 
-  if (prefectureTrajectoryChart) {
-    prefectureTrajectoryChart.destroy();
+  if (trajectoryChart) {
+    trajectoryChart.destroy();
   }
 
-  prefectureTrajectoryChart = c3.generate({
-    bindto: "#prefecture-trajectory",
+  trajectoryChart = c3.generate({
+    bindto: bindElement,
     size: {
       height: 500,
     },
@@ -149,12 +146,11 @@ const drawPrefectureTrajectoryChart = (
     tooltip: {
       format: {
         value: (value, ratio, id, index) => {
-          const prefecture = trajectories[id];
-          if (index && prefecture.cumulativeConfirmed[index - 1]) {
-            const diff =
-              parseInt(value) - prefecture.cumulativeConfirmed[index - 1];
+          const area = trajectories[id];
+          if (index && area.cumulativeConfirmed[index - 1]) {
+            const diff = parseInt(value) - area.cumulativeConfirmed[index - 1];
             const annotation =
-              index === prefecture.lastIndex ? i18next.t("provisional") : "";
+              index === area.lastIndex ? i18next.t("provisional") : "";
             const sign = diff >= 0 ? "+" : "";
             const diffText = `${sign}${formatNumber(diff)}`;
             return `${formatNumber(value)} (${diffText}) ${annotation}`;
@@ -165,7 +161,32 @@ const drawPrefectureTrajectoryChart = (
       },
     },
   });
-  return prefectureTrajectoryChart;
+  return trajectoryChart;
 };
 
-export default drawPrefectureTrajectoryChart;
+export const drawPrefectureTrajectoryChart = (
+  prefectures,
+  trajectoryChart,
+  lang
+) => {
+  return drawTrajectoryChart(
+    prefectures.filter((prefecture) => !prefecture.pseudoPrefecture),
+    trajectoryChart,
+    lang,
+    "#prefecture-trajectory",
+    "prefectures"
+  );
+};
+export const drawRegionTrajectoryChart = (
+  regions,
+  regionTrajectoryChart,
+  lang
+) => {
+  return drawTrajectoryChart(
+    regions,
+    regionTrajectoryChart,
+    lang,
+    "#regional-trajectory",
+    "regions"
+  );
+};

--- a/src/components/TrajectoryChart/TrajectoryChart.js
+++ b/src/components/TrajectoryChart/TrajectoryChart.js
@@ -164,19 +164,6 @@ const drawTrajectoryChart = (
   return trajectoryChart;
 };
 
-export const drawPrefectureTrajectoryChart = (
-  prefectures,
-  trajectoryChart,
-  lang
-) => {
-  return drawTrajectoryChart(
-    prefectures.filter((prefecture) => !prefecture.pseudoPrefecture),
-    trajectoryChart,
-    lang,
-    "#prefecture-trajectory",
-    "prefectures"
-  );
-};
 export const drawRegionTrajectoryChart = (
   regions,
   regionTrajectoryChart,

--- a/src/components/TrajectoryChart/index.js
+++ b/src/components/TrajectoryChart/index.js
@@ -1,3 +1,0 @@
-import drawPrefectureTrajectoryChart from "./TrajectoryChart";
-
-export default drawPrefectureTrajectoryChart;

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -26,7 +26,7 @@
   "active": "حالات نشطة حاليا",
   "helpful-links": "روابط مساعدة",
   "primary-data-sources": "المصادر المرجعية للبيانات",
-  "confirmed-case-trajectories-by-prefecture": "مسارات الاصابات في كل محافظة",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": " عدد الايام منذ تخطي {{minimumConfirmed}} اصابة ",
   "traveling-into-japan": "السفر الي اليابان",
   "about-travel-restriction": "هذه معلومات عن حظر السفر الي اليابان. برجاء الضعط على الروابط في الاسفل للحصول على معلومات تفصيلية",

--- a/src/i18n/bn.json
+++ b/src/i18n/bn.json
@@ -25,7 +25,7 @@
   "active": "সক্রিয়",
   "helpful-links": "উপকারী লিঙ্কসমূহ",
   "primary-data-sources": "প্রাথমিক তথ্য সূত্রসমূহ",
-  "confirmed-case-trajectories-by-prefecture": "প্রিফেকচার অনুযায়ী সনাক্তের ট্রাজেক্টোরি-চিত্র",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "{{minimumConfirmed}}তম সনাক্তের পর থেকে দিনের সংখ্যা",
   "traveling-into-japan": "জাপানে ভ্রমণ",
   "about-travel-restriction": "জাপানে ভ্রমণবিষয়ক নিষেধাজ্ঞাগুলো নিচে দেওয়া হল। বিধিনিষেধ সম্পর্কে আরও তথ্যের জন্য লিঙ্কে ক্লিক করুন।",

--- a/src/i18n/cs.json
+++ b/src/i18n/cs.json
@@ -24,7 +24,7 @@
   "active": "Aktivních",
   "helpful-links": "Informativní Odkazy",
   "primary-data-sources": "Hlavní Zdroj Dat",
-  "confirmed-case-trajectories-by-prefecture": "Graf Potvrzených Případů rozdělený podle Prefektur",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Počet dní od {{minimumConfirmed}}ho případu",
   "traveling-into-japan": "Cestování do Japonska",
   "about-travel-restriction": "Níže jsou platné opatření týkající se cestování do Japonska. Pro více informací klikněte na odkaz.",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -24,7 +24,7 @@
   "active": "Aktiv",
   "helpful-links": "Hilfreiche Links",
   "primary-data-sources": "Primäre Datenquellen",
-  "confirmed-case-trajectories-by-prefecture": "Verlauf bestätigter Fälle pro Präfektur (> 100 Fälle)",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "traveling-into-japan": "Einreise nach Japan",
   "about-travel-restriction": "Nachfolgend sind bestehende Einreisebeschränkungen nach Japan aufgelistet. Mehr Informationen sind nach einem Klick auf die jeweilige Beschränkung verfügbar.",
   "banned-from-entering-japan": "Dürfen nicht nach Japan einreisen:",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,7 +26,6 @@
   "active": "Active",
   "helpful-links": "Helpful Links",
   "primary-data-sources": "Primary Data Sources",
-  "confirmed-case-trajectories-by-prefecture": "Confirmed Case Trajectories by Prefecture",
   "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Number of days since {{minimumConfirmed}}th case",
   "traveling-into-japan": "Traveling into Japan",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -27,6 +27,7 @@
   "helpful-links": "Helpful Links",
   "primary-data-sources": "Primary Data Sources",
   "confirmed-case-trajectories-by-prefecture": "Confirmed Case Trajectories by Prefecture",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Number of days since {{minimumConfirmed}}th case",
   "traveling-into-japan": "Traveling into Japan",
   "about-travel-restriction": "Below are the travel restrictions that have been put in place regarding traveling into Japan. Click on the link for more details on the restrictions.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -25,7 +25,7 @@
   "active": "Activos",
   "helpful-links": "Enlaces útiles",
   "primary-data-sources": "Fuentes de datos primarios",
-  "confirmed-case-trajectories-by-prefecture": "Trayectorias de casos confirmados por prefectura",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Número de días desde el caso {{minimumConfirmed}}",
   "traveling-into-japan": "Viajando a Japón",
   "about-travel-restriction": "A continuación se detallan las restricciones de viaje que se han establecido para viajar a Japón. Haga clic en el enlace para obtener más detalles sobre las restricciones..",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -26,6 +26,7 @@
   "helpful-links": "Hyödyllisiä linkkejä",
   "primary-data-sources": "Pääasialliset tietolähteet",
   "confirmed-case-trajectories-by-prefecture": "Varmistettujen tapauksien kehitys prefektuureittain",
+  "confirmed-case-trajectories-by-region": "Varmistettujen tapauksien kehitys alueittain",
   "trajectory-description": "Päivää {{minimumConfirmed}}. tapauksesta",
   "traveling-into-japan": "Matkustaminen Japaniin",
   "about-travel-restriction": "Alla on listattu Japaniin matkustamista kohtevia rajoituksia. Klikkaa linkkiä saadaksesi lisätietoa rajoituksista.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -25,7 +25,6 @@
   "active": "Aktiivisia",
   "helpful-links": "Hyödyllisiä linkkejä",
   "primary-data-sources": "Pääasialliset tietolähteet",
-  "confirmed-case-trajectories-by-prefecture": "Varmistettujen tapauksien kehitys prefektuureittain",
   "confirmed-case-trajectories-by-region": "Varmistettujen tapauksien kehitys alueittain",
   "trajectory-description": "Päivää {{minimumConfirmed}}. tapauksesta",
   "traveling-into-japan": "Matkustaminen Japaniin",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -24,7 +24,7 @@
   "active": "Actifs",
   "helpful-links": "Liens utiles",
   "primary-data-sources": "Source d'information principale",
-  "confirmed-case-trajectories-by-prefecture": "Trajectoire des cas confirmés par préfecture",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Nombre de jours depuis le {{minimumConfirmed}}ème cas confirmé",
   "traveling-into-japan": "Voyageant au Japon",
   "about-travel-restriction": "Ci-dessous sont listés les restrictions qui ont été mises en place concernant les voyages au Japon. Cliquez sour le lien pour plus de détails concernant ces restrictions.",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -25,7 +25,7 @@
   "active": "सक्रिय",
   "helpful-links": "सहायक सूचना",
   "primary-data-sources": "प्राथमिक सूचना स्रोत",
-  "confirmed-case-trajectories-by-prefecture": "प्रांत अनुसार पुष्ट विषय मार्ग",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "{{minimumConfirmed}}वे विषय से अब तक व्यतीत दिन",
   "traveling-into-japan": "जापान में यात्रा",
   "about-travel-restriction": "विभिन्न देशों द्वारा जारी प्रवेशवर्जित सूची निम्न है। विस्तार से जानने के लिए देश के नाम पर दबाएँ 。",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -27,7 +27,7 @@
   "active": "Aktif",
   "helpful-links": "Tautan Berguna",
   "primary-data-sources": "Sumber Data Utama",
-  "confirmed-case-trajectories-by-prefecture": "Lintasan Kasus Terkonfirmasi berdasarkan Prefektur (> 100 kasus)",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Jumlah hari sejak kasus ke-{{minimumConfirmed}}",
   "traveling-into-japan": "Bepergian ke Jepang",
   "about-travel-restriction": "Di bawah ini adalah daftar negara yang dikenakan pembatasan perjalanan ke Jepang. Klik tautan untuk rincian lebih lanjut tentang pembatasan.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -24,7 +24,7 @@
   "active": "Attivi",
   "helpful-links": "Collegamenti utili",
   "primary-data-sources": "Fonti Principali dei dati",
-  "confirmed-case-trajectories-by-prefecture": "Traiettora per Prefettura dei Casi Confermati",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Numero dei giorni dal {{minimumConfirmed}}esimo caso",
   "traveling-into-japan": "Viaggiare in Giappone",
   "about-travel-restriction": "Seguono le restrizioni messe in atto riguardante il viaggiare in Giappone. Clicca sui link per saperne di più.",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -25,7 +25,7 @@
   "active": "既存感染者数",
   "helpful-links": "有益な情報源",
   "primary-data-sources": "一次情報源",
-  "confirmed-case-trajectories-by-prefecture": "都道府県別の感染者数推移",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Number of days since {{minimumConfirmed}}th case",
   "traveling-into-japan": "入国制限について",
   "about-travel-restriction": "下記に各国の入国制限に関する一覧がございます。詳細をご覧いただくには、国名をクリックしてください。",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -24,7 +24,7 @@
   "active": "Aktywne",
   "helpful-links": "Przydatne Linki",
   "primary-data-sources": "Główne Źródła Danych",
-  "confirmed-case-trajectories-by-prefecture": "Trajektorie Potwierdzonych Przypadków według Prefektur",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Liczba dni od przypadku numer: {{minimumConfirmed}}",
   "traveling-into-japan": "Podróżowanie do Japonii",
   "about-travel-restriction": "Poniżej znajdują się informacje o ograniczeniach w podróżowaniu do Japonii. Kliknij w link, aby uzyskać więcej szczegółów.",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -24,7 +24,7 @@
   "active": "Ativos",
   "helpful-links": "Links Úteis",
   "primary-data-sources": "Fontes Primárias de Dados",
-  "confirmed-case-trajectories-by-prefecture": "Acumulado de Casos Confirmados por Província",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Número de dias desde o {{minimumConfirmed}}º caso",
   "traveling-into-japan": "Viajando ao Japão",
   "about-travel-restriction": "Abaixo constam as retrições colocadas em prática com relação a viagens ao Japão. Clique nos links para mais detalhes sobre as restrições.",

--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -25,7 +25,7 @@
   "active": "Активні",
   "helpful-links": "Корисні Посилання",
   "primary-data-sources": "Основні Джерела Даних",
-  "confirmed-case-trajectories-by-prefecture": "Траєкторії Підтверджених Випадків по Префектурі",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "Кількість днів з {{minimumConfirmed}}-го випадку",
   "traveling-into-japan": "В'їзд в Японію",
   "about-travel-restriction": "Нижче наведено діючі обмеження на в'їзд в Японію. Клацніть на посилання, щоб отримати докладнішу інформацію про обмеження.",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -23,7 +23,7 @@
   "active": "活性",
   "helpful-links": "有用的網址",
   "primary-data-sources": "主要數據源",
-  "confirmed-case-trajectories-by-prefecture": "按地區確認的病例軌跡",
+  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
   "trajectory-description": "自第{{minimumConfirmed}}起案件以來的天數",
   "traveling-into-japan": "前往日本",
   "about-travel-restriction": "以下是對赴日旅行的限制。 單擊鏈接以獲取有關限制的更多詳細信息。",

--- a/src/index.html
+++ b/src/index.html
@@ -226,24 +226,13 @@
 
     </section>
 
-    <section id="trajectories" class="embed-hide">
-      <section id="regional-trajectory-container" class="embed-hide">
-        <h4 data-i18n="confirmed-case-trajectories-by-region">Confirmed Case Trajectories by Region</h4>
-        <div id="regional-trajectory-chart-box">
-          <div id="regional-trajectory">
-            <div class="loader"><div class="lds-dual-ring"></div></div>
-          </div>
+    <section id="regional-trajectory-container" class="embed-hide">
+      <h4 data-i18n="confirmed-case-trajectories-by-region">Confirmed Case Trajectories by Region</h4>
+      <div id="regional-trajectory-chart-box">
+        <div id="regional-trajectory">
+          <div class="loader"><div class="lds-dual-ring"></div></div>
         </div>
-      </section>
-
-      <section id="prefecture-trajectory-container" class="embed-hide">
-        <h4 data-i18n="confirmed-case-trajectories-by-prefecture">Confirmed Case Trajectories by Prefecture</h4>
-        <div id="prefecture-trajectory-chart-box">
-          <div id="prefecture-trajectory">
-            <div class="loader"><div class="lds-dual-ring"></div></div>
-          </div>
-        </div>
-      </section>
+      </div>
     </section>
   
     <section id="travel-restrictions" class="embed-hide">

--- a/src/index.html
+++ b/src/index.html
@@ -226,16 +226,25 @@
 
     </section>
 
-
-    <section id="prefecture-trajectory-container" class="embed-hide">
-      <h4 data-i18n="confirmed-case-trajectories-by-prefecture">Confirmed Case Trajectories by Prefecture</h4>
-      <div id="prefecture-trajectory-chart-box">
-        <div id="prefecture-trajectory">
-          <div class="loader"><div class="lds-dual-ring"></div></div>
+    <section id="trajectories" class="embed-hide">
+      <section id="regional-trajectory-container" class="embed-hide">
+        <h4 data-i18n="confirmed-case-trajectories-by-region">Confirmed Case Trajectories by Region</h4>
+        <div id="regional-trajectory-chart-box">
+          <div id="regional-trajectory">
+            <div class="loader"><div class="lds-dual-ring"></div></div>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
+      <section id="prefecture-trajectory-container" class="embed-hide">
+        <h4 data-i18n="confirmed-case-trajectories-by-prefecture">Confirmed Case Trajectories by Prefecture</h4>
+        <div id="prefecture-trajectory-chart-box">
+          <div id="prefecture-trajectory">
+            <div class="loader"><div class="lds-dual-ring"></div></div>
+          </div>
+        </div>
+      </section>
+    </section>
   
     <section id="travel-restrictions" class="embed-hide">
       <h4 data-i18n="traveling-into-japan">Traveling into Japan</h4>

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ import drawKpis from "./components/Kpi";
 import mapDrawer from "./components/OutbreakMap";
 import PrefectureTable from "./components/PrefectureTable";
 import drawTrendChart from "./components/SpreadTrendChart";
-import drawPrefectureTrajectoryChart from "./components/TrajectoryChart";
+import {
+  drawPrefectureTrajectoryChart,
+  drawRegionTrajectoryChart,
+} from "./components/TrajectoryChart/TrajectoryChart";
 import drawTravelRestrictions from "./components/TravelRestrictions";
 import {
   drawRegionalCharts,
@@ -124,6 +127,7 @@ let dailyIncreaseChart = null;
 
 // Keep reference to chart in order to destroy it when redrawing.
 let prefectureTrajectoryChart = null;
+let regionTrajectoryChart = null;
 
 // localize must be accessible globally
 const localize = locI18next.init(i18next);
@@ -180,6 +184,11 @@ const setLang = (lng) => {
         prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
           ddb.prefectures,
           prefectureTrajectoryChart,
+          LANG
+        );
+        regionTrajectoryChart = drawRegionTrajectoryChart(
+          ddb.regions,
+          regionTrajectoryChart,
           LANG
         );
         drawTopRegions(ddb.prefectures, ddb.regions, LANG);
@@ -351,6 +360,11 @@ document.addEventListener("covid19japan-redraw", () => {
       prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
         ddb.prefectures,
         prefectureTrajectoryChart,
+        LANG
+      );
+      regionTrajectoryChart = drawRegionTrajectoryChart(
+        ddb.regions,
+        regionTrajectoryChart,
         LANG
       );
     }, 32);

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,7 @@ import drawKpis from "./components/Kpi";
 import mapDrawer from "./components/OutbreakMap";
 import PrefectureTable from "./components/PrefectureTable";
 import drawTrendChart from "./components/SpreadTrendChart";
-import {
-  drawPrefectureTrajectoryChart,
-  drawRegionTrajectoryChart,
-} from "./components/TrajectoryChart/TrajectoryChart";
+import { drawRegionTrajectoryChart } from "./components/TrajectoryChart/TrajectoryChart";
 import drawTravelRestrictions from "./components/TravelRestrictions";
 import {
   drawRegionalCharts,
@@ -126,7 +123,6 @@ let trendChart = null;
 let dailyIncreaseChart = null;
 
 // Keep reference to chart in order to destroy it when redrawing.
-let prefectureTrajectoryChart = null;
 let regionTrajectoryChart = null;
 
 // localize must be accessible globally
@@ -180,11 +176,6 @@ const setLang = (lng) => {
           dailyIncreaseChart,
           LANG,
           CHART_TIME_PERIOD
-        );
-        prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
-          ddb.prefectures,
-          prefectureTrajectoryChart,
-          LANG
         );
         regionTrajectoryChart = drawRegionTrajectoryChart(
           ddb.regions,
@@ -357,11 +348,6 @@ document.addEventListener("covid19japan-redraw", () => {
       );
     });
     callIfUpdated(() => {
-      prefectureTrajectoryChart = drawPrefectureTrajectoryChart(
-        ddb.prefectures,
-        prefectureTrajectoryChart,
-        LANG
-      );
       regionTrajectoryChart = drawRegionTrajectoryChart(
         ddb.regions,
         regionTrajectoryChart,

--- a/src/index.scss
+++ b/src/index.scss
@@ -180,16 +180,34 @@ a, a:hover, a:visited {
   }
 }
 
+// National charts
+#trajectories { width: 100%; }
 
-#prefecture-trajectory-container {
-  max-width: 800px;
-  margin: 0 auto;
+@media (min-width: $breakpoint-960) {
+  #trajectories {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    //align-items: stretch;
+  }
+  #regional-trajectory-container {
+    margin: 10px;
+    flex: 1;
+    width: 50%;
+  }
+  #prefecture-trajectory-container {
+    margin: 10px;
+    flex: 1;
+    width: 50%;
+  }
 }
 
+#regional-trajectory-chart,
 #prefecture-trajectory-chart {
   min-height: 500px;
 }
 
+#regional-trajectory-chart-box,
 #prefecture-trajectory-chart-box {
   padding: 10px 10px 5px 10px;
   border-radius: $box-border-radius;
@@ -296,6 +314,7 @@ img.emoji {
 // c3 chart styling
 #trend-chart-container,
 #daily-increase-container,
+#regional-trajectory-container,
 #prefecture-trajectory-container {
   path.c3-line {
     stroke-width: 2px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -183,32 +183,15 @@ a, a:hover, a:visited {
 // National charts
 #trajectories { width: 100%; }
 
-@media (min-width: $breakpoint-960) {
-  #trajectories {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    //align-items: stretch;
-  }
-  #regional-trajectory-container {
-    margin: 10px;
-    flex: 1;
-    width: 50%;
-  }
-  #prefecture-trajectory-container {
-    margin: 10px;
-    flex: 1;
-    width: 50%;
-  }
+#regional-trajectory-container {
+  margin: 5px;
 }
 
-#regional-trajectory-chart,
-#prefecture-trajectory-chart {
+#regional-trajectory-chart {
   min-height: 500px;
 }
 
-#regional-trajectory-chart-box,
-#prefecture-trajectory-chart-box {
+#regional-trajectory-chart-box {
   padding: 10px 10px 5px 10px;
   border-radius: $box-border-radius;
   background: $color-box-background;
@@ -314,8 +297,7 @@ img.emoji {
 // c3 chart styling
 #trend-chart-container,
 #daily-increase-container,
-#regional-trajectory-container,
-#prefecture-trajectory-container {
+#regional-trajectory-container {
   path.c3-line {
     stroke-width: 2px;
   }


### PR DESCRIPTION
Hi @reustle @liquidx 

Since the data is now grouped by regions, too, I thought the confirmed case trajectories chart being only for prefectures was lacking, so I duplicated it for regions, too:

<img width="1201" alt="Screen Shot 2020-07-21 at 14 26 23" src="https://user-images.githubusercontent.com/2044745/88017247-413c6f00-cb60-11ea-95a4-4d7c7afb2619.png">
