### PR TITLE
Reduce the font size of languages bar

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -86,6 +86,7 @@ header {
     }
     
     .lang-picker {
+      font-size: 12px;
       padding: 0.5rem 1em 0.5em 0;
       a {
         white-space: nowrap;


### PR DESCRIPTION
Reduce the font size of the languages bar to 12px to keep all the languages on the same row.
