### PR TITLE
Missing translation added for IT.json

### DIFF
--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -24,7 +24,7 @@
   "active": "Attivi",
   "helpful-links": "Collegamenti utili",
   "primary-data-sources": "Fonti Principali dei dati",
-  "confirmed-case-trajectories-by-region": "Confirmed Case Trajectories by Region",
+  "confirmed-case-trajectories-by-region": "Curva dei casi confermati per Regione",
   "trajectory-description": "Numero dei giorni dal {{minimumConfirmed}}esimo caso",
   "traveling-into-japan": "Viaggiare in Giappone",
   "about-travel-restriction": "Seguono le restrizioni messe in atto riguardante il viaggiare in Giappone. Clicca sui link per saperne di più.",


### PR DESCRIPTION
"Confirmed Case Trajectories by Region" translated in Italian with "Curva dei casi confermati per Regione". In Italian language it is differentiated between trajectory  and curve. With this kind of graphs "curva" is the proper one.

@reustle 

// Please tag @reustle in your newly created PR

// Please include a screenshot of any visual changes you've made
