### PR TITLE
Adjust the left padding of "Total Cases" chart

### DIFF
--- a/src/components/SpreadTrendChart/SpreadTrend.js
+++ b/src/components/SpreadTrendChart/SpreadTrend.js
@@ -153,7 +153,7 @@ const drawTrendChart = (
       },
     },
     padding: {
-      left: 40,
+      left: 45,
       right: 10,
       top: 0,
       bottom: 0,


### PR DESCRIPTION
// Please tag  in your newly created PR

Hello, @reustle. 🙂
At first, thank you for creating this dashboard. This dashboard is always very useful to understand trends of COVID-19 in Japan from the early days of this pandemic.

**Problem & What this PR fixes**

The total cases in Japan are continuing to increase and the Y-axis label reached 100,000. It causes the overflow of the most left character of the label.

This PR add 5px to the left padding of the chart and fix that problem.

**Before**

![Screenshot from 2020-10-17 21-36-01](https://user-images.githubusercontent.com/1425259/96337561-1ca25580-10c3-11eb-8249-48873901f4ea.png)

**After**

![Screenshot from 2020-10-17 21-36-08](https://user-images.githubusercontent.com/1425259/96337560-1c09bf00-10c3-11eb-81b1-6c624e6c97d0.png)
