### PR TITLE
[FIX] time period selection

### DIFF
--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -31,6 +31,9 @@ const drawDailyIncreaseChart = (
 
   const startIndex = timePeriod > 0 ? trends.length - timePeriod : 0;
   for (let i = startIndex; i < trends.length; i++) {
+    // added next line for throttling, because chart lagging for all period of time
+    if (startIndex === 0 && i % 2 === 0) continue;
+
     const row = trends[i];
 
     cols.Date.push(row.date);

--- a/src/components/DailyIncreaseChart/DailyIncrease.js
+++ b/src/components/DailyIncreaseChart/DailyIncrease.js
@@ -112,7 +112,7 @@ const drawDailyIncreaseChart = (
               return "";
             }
             const xDate = Date.parse(x);
-            return format(xDate, "MMM d", {
+            return format(xDate, "MMM d yyyy", {
               locale: dateLocale,
               addSuffix: true,
             });

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -2,9 +2,8 @@ import languageResources, { LANGUAGES } from "../i18n";
 
 export const TIME_FORMAT = "MMMM d yyyy, HH:mm";
 
-// TODO: Properly calculate the all time period. Currently hardcoded to 6 months.
-export const TIME_PERIOD_ALL_TIME = 240;
-export const TIME_PERIOD_THREE_MONTHS = 120;
+export const TIME_PERIOD_ALL_TIME = 0;
+export const TIME_PERIOD_THREE_MONTHS = 90;
 
 export const COLOR_ACTIVE = "rgb(223,14,31)";
 export const COLOR_ACTIVE_LIGHT = " rgb(223, 144, 144)";


### PR DESCRIPTION
Fixed time period for daily charts, fix 3 month value(was 4 instead) and all period was pointed to 6 months not for all, because all period daily chart lagging used every second data value

// Please include a screenshot of any visual changes you've made
There is no any visual changes, except All time chart contains bigger amount of data