### PR TITLE
Fix dead link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -346,7 +346,7 @@
           </a>
         </li>
         <li>
-          <a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/tagengoguide.files/tagengogaido2019-mihiraki.pdf">
+          <a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/tagengoguide.files/guidebook2020_mihiraki.pdf">
             Monitoring your symptoms if you feel ill
           </a>
         </li>


### PR DESCRIPTION
The original link goes returns a 404. The new link has an updated version of the original guide.