### PR TITLE
Fix number overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5800,6 +5800,7 @@
         "node-pre-gyp"
       ],
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -17,4 +17,12 @@ $breakpoint-600-page-width: $breakpoint-600 - $min-page-margins;
 $breakpoint-500: 500px;
 $breakpoint-500-page-width: $breakpoint-500 - $min-page-margins;
 
+$breakpoint-375: 375px;
+$breakpoint-375-less-than: 374px;
+$breakpoint-375-page-width: $breakpoint-375 - $min-page-margins;
+
+$breakpoint-425: 425px;
+$breakpoint-425-less-than: 424px;
+$breakpoint-425-page-width: $breakpoint-425 - $min-page-margins;
+
 $box-border-radius: 10px;

--- a/src/components/OutbreakMap/_map.scss
+++ b/src/components/OutbreakMap/_map.scss
@@ -3,18 +3,25 @@
 
 $map-color-background: #cad2d3;
 
+#prefecture-map-contents img {
+  width: 100%;
+  border-radius: 10px;
+  cursor: zoom-in;
+}
+
+#map-container {
+  display: none;
+  width: 100%;
+  height: 500px;
+  background: $map-color-background;
+  border-radius: $box-border-radius;
+}
+
 #map-container {
   width: 100%;
   height: 500px;
   background: $map-color-background;
   border-radius: $box-border-radius;
-
-  img {
-    width: 100%;
-    height: 100%;
-    border-radius: 10px;
-    cursor: zoom-in;
-  }
 }
 
 #map-legend {

--- a/src/components/RegionalCharts/_regional.scss
+++ b/src/components/RegionalCharts/_regional.scss
@@ -107,6 +107,18 @@ $breakpoint-600-full-box-width: $breakpoint-600-page-width - $box-margin * 2;
   }
 }
 
+// Layout if screensize at 375px or higher
+
+@media (min-width: $breakpoint-375) {
+  .region-box .value {
+    font-size: 1.125rem !important;
+  }
+
+  .region-box .diff {
+    display: inline-block !important;
+  }
+}
+
 // Layout 2: Between 1200px and 960px
 
 @media (min-width: $breakpoint-960) and (max-width: $breakpoint-1200-less-than) {

--- a/src/index.html
+++ b/src/index.html
@@ -283,11 +283,7 @@
     <section id="prefecture-sections">
       <section id="prefecture-map-container">       
         <a name="map"><h4><span data-i18n="covid-19" class="embed-show">COVID-19</span> <span data-i18n="outbreak-map">Outbreak Map</span></h4></a>
-        <div id="prefecture-map-contents">
-          <div id="map-container"></div>
-          <p class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></p>
-          <div id="map-legend"></div>
-        </div>
+        <div id="prefecture-map-contents"></div>
       </section>    
 
       <section id="prefecture-top-table-container" class="embed-hide">

--- a/src/index.js
+++ b/src/index.js
@@ -282,14 +282,22 @@ const doInitMap = () => {
   // insert static map from mapbox static API;
   const prefecturePaint = JSON.stringify(getPrefecturePaint(ddb.prefectures));
 
-  document.getElementById(
-    "map-container"
-  ).innerHTML = `<img id="static-map" src='https://api.mapbox.com/styles/v1/reustle/cko2t3n7x0pjr17p80e1tlavj/static/138.1179,37.5767,4.03,0/570x500@2x?before_layer=admin-1-boundary&addlayer={"id":"prefecture-layer","type":"fill","source":"composite","source-layer":"prefectures-smooth-1d4tx6","paint":{"fill-color":${prefecturePaint},"fill-opacity":1}}&access_token=${MAPBOX_API_KEY}' alt="Prefecture map">`;
+  document.getElementById("prefecture-map-contents").innerHTML = `
+  <img id="static-map" src='https://api.mapbox.com/styles/v1/reustle/cko2t3n7x0pjr17p80e1tlavj/static/138.1179,37.5767,4.03,0/570x500@2x?before_layer=admin-1-boundary&addlayer={"id":"prefecture-layer","type":"fill","source":"composite","source-layer":"prefectures-smooth-1d4tx6","paint":{"fill-color":${prefecturePaint},"fill-opacity":1}}&access_token=${MAPBOX_API_KEY}' alt="Prefecture map">
+  <div id="map-container"></div>
+  <p class="embed-show footnote">powered by <a href="https://covid19japan.com" target="_blank">COVID19Japan.com</a></p>
+  <div id="map-legend"></div>`;
 
   // add event listener to replace static map on click with real one
   const staticMap = document.getElementById("static-map");
+  const mapContainer = document.getElementById("map-container");
+
   staticMap.addEventListener("click", (e) => {
     e.preventDefault();
+
+    staticMap.style.display = "none";
+
+    mapContainer.style.display = "block";
 
     let map = PAGE_STATE.map;
 


### PR DESCRIPTION
// Please include a screenshot of any visual changes you've made

1. Add new breakpoint variable 375px and 425px on _layout.scss, 
2. Add new breakpoint 375px on _regional.scss to decrease the font-size by .4 rem and the diff display to inline-block

<img width="1440" alt="Screen Shot 2022-08-02 at 08 52 32" src="https://user-images.githubusercontent.com/52234049/182295746-69277274-4aa8-4ee2-b681-08b612638b60.png">
<img width="1061" alt="Screen Shot 2022-08-02 at 10 18 44" src="https://user-images.githubusercontent.com/52234049/182295767-0dc2854f-d0a3-47d2-a48d-2a467b96053b.png">